### PR TITLE
Remove hover beam and add tvbox config

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4690,6 +4690,43 @@ function AdminPageClient() {
               <LiveSourceConfig config={config} refreshConfig={fetchConfig} />
             </CollapsibleTab>
 
+            {/* TVbox 配置 */}
+            <CollapsibleTab
+              title='TVbox配置'
+              icon={
+                <Tv size={20} className='text-gray-600 dark:text-gray-400' />
+              }
+              isExpanded={false}
+              onToggle={() => { }}
+            >
+              <div className='space-y-4 p-4'>
+                <div className='text-sm text-gray-600 dark:text-gray-300'>
+                  TVBox 订阅地址已为你生成，可在 TVBox/猫影视 等应用中添加为订阅源：
+                </div>
+                <div className='flex items-center gap-2'>
+                  <input
+                    type='text'
+                    readOnly
+                    className='w-full px-3 py-2 rounded-md bg-gray-100 dark:bg-gray-900/40 text-gray-800 dark:text-gray-100 border border-gray-200 dark:border-gray-700'
+                    value={`${typeof window !== 'undefined' ? window.location.origin : ''}/api/tvbox/config`}
+                  />
+                  <button
+                    onClick={() => {
+                      const url = `${window.location.origin}/api/tvbox/config`;
+                      navigator.clipboard.writeText(url);
+                    }}
+                    className={buttonStyles.primary}
+                  >
+                    复制
+                  </button>
+                </div>
+                <ul className='list-disc pl-6 text-sm text-gray-500 dark:text-gray-400 space-y-1'>
+                  <li>常见入口：设置 → 订阅管理 → 添加订阅。</li>
+                  <li>本订阅包含“视频源”和“直播源”，与你在此后台启用的配置同步。</li>
+                </ul>
+              </div>
+            </CollapsibleTab>
+
             {/* 分类配置标签 */}
             <CollapsibleTab
               title='分类配置'

--- a/src/app/api/tvbox/config/route.ts
+++ b/src/app/api/tvbox/config/route.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, no-console */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getConfig } from '@/lib/config';
+
+export const runtime = 'nodejs';
+
+// TVBox 订阅格式（常见的 drpy/猫影视样式的简化版）
+// 文档参考社区资料：输出 sites、lives 两部分即可被多数 TVBox 分支识别
+
+export async function GET(_req: NextRequest) {
+  try {
+    const cfg = await getConfig();
+
+    const sites = (cfg.SourceConfig || [])
+      .filter((s) => !s.disabled)
+      .map((s) => ({
+        key: s.key,
+        name: s.name,
+        api: s.api,
+        type: 1, // 1: 通用 xml/json 采集接口
+        searchable: 1,
+        quickSearch: 1,
+        filterable: 1,
+        ext: s.detail || ''
+      }));
+
+    const lives = (cfg.LiveConfig || [])
+      .filter((l) => !l.disabled)
+      .map((l) => ({
+        name: l.name,
+        // TVBox 支持直链或 m3u 链接
+        url: l.url,
+        ua: l.ua || '',
+        epg: l.epg || ''
+      }));
+
+    const payload = {
+      sites,
+      lives
+    };
+
+    return new NextResponse(JSON.stringify(payload, null, 2), {
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store'
+      },
+    });
+  } catch (e) {
+    console.error('TVBox 配置生成失败:', e);
+    return NextResponse.json({ error: 'TVBox 配置生成失败' }, { status: 500 });
+  }
+}
+

--- a/src/components/ParticleBackground.tsx
+++ b/src/components/ParticleBackground.tsx
@@ -62,17 +62,8 @@ export default function ParticleBackground() {
       ctx.fillStyle = gradient;
       ctx.fillRect(0, 0, width, height);
 
-      // Light beams
-      const beamCount = 3;
-      for (let i = 0; i < beamCount; i++) {
-        const x = ((Date.now() / 2000 + i / beamCount) % 1) * width;
-        const grd = ctx.createLinearGradient(x - 80, 0, x + 80, height);
-        grd.addColorStop(0, 'transparent');
-        grd.addColorStop(0.5, theme.beam);
-        grd.addColorStop(1, 'transparent');
-        ctx.fillStyle = grd;
-        ctx.fillRect(x - 100, 0, 200, height);
-      }
+      // 取消“竖向高光光波横扫”效果，避免干扰视觉
+      // 原先这里会绘制随时间移动的竖向光束
 
       // Particles
       for (const p of particles) {


### PR DESCRIPTION
Removes the distracting homepage sweeping highlight effect and adds TVbox configuration with an admin panel button.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d8e6e1f-13ea-44c8-8035-c082b08ebea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d8e6e1f-13ea-44c8-8035-c082b08ebea8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

