### PR TITLE
修复播放页 unknown 年份误判与搜索页结果展示异常

### DIFF
--- a/src/app/play/page.tsx
+++ b/src/app/play/page.tsx
@@ -407,6 +407,34 @@ function sanitizeDanmukuSettings(raw: unknown): DanmukuSettings {
   };
 }
 
+function normalizeYearForMatch(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (
+    !normalized ||
+    normalized === 'unknown' ||
+    normalized === '0' ||
+    normalized === 'null' ||
+    normalized === 'undefined'
+  ) {
+    return '';
+  }
+
+  const matchedYear = normalized.match(/\d{4}/)?.[0];
+  return matchedYear || '';
+}
+
+function matchesRequestedYear(
+  resultYear: string,
+  requestedYear: string,
+): boolean {
+  const normalizedRequestedYear = normalizeYearForMatch(requestedYear);
+  if (!normalizedRequestedYear) {
+    return true;
+  }
+
+  return normalizeYearForMatch(resultYear) === normalizedRequestedYear;
+}
+
 /**
  * 从 localStorage 读取弹幕播放器偏好
  * @returns 合并默认值后的弹幕设置
@@ -2149,9 +2177,7 @@ function PlayPageClient() {
           (result: SearchResult) =>
             result.title.replaceAll(' ', '').toLowerCase() ===
               videoTitleRef.current.replaceAll(' ', '').toLowerCase() &&
-            (videoYearRef.current
-              ? result.year.toLowerCase() === videoYearRef.current.toLowerCase()
-              : true) &&
+            matchesRequestedYear(result.year || '', videoYearRef.current) &&
             (searchType
               ? (searchType === 'tv' && result.episodes.length > 1) ||
                 (searchType === 'movie' && result.episodes.length === 1)

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -562,6 +562,14 @@ function SearchPageClient() {
     }
   }, [aggregatedResults, filterAgg, searchQuery]);
 
+  const displayedResultCount = useMemo(() => {
+    if (viewMode === 'agg') {
+      return Array.isArray(filteredAggResults) ? filteredAggResults.length : 0;
+    }
+
+    return Array.isArray(filteredAllResults) ? filteredAllResults.length : 0;
+  }, [filteredAggResults, filteredAllResults, viewMode]);
+
   useEffect(() => {
     // 无搜索参数时聚焦搜索框
     !searchParams.get('q') && document.getElementById('searchInput')?.focus();
@@ -688,6 +696,46 @@ function SearchPageClient() {
       setUseFluidSearch(currentFluidSearch);
     }
 
+    const fetchCanonicalSearchResults = async (
+      completedSourceCount: number,
+    ): Promise<boolean> => {
+      try {
+        const response = await fetch(
+          '/api/search?q=' + encodeURIComponent(trimmed),
+        );
+        if (!response.ok) {
+          throw new Error(
+            'search request failed with status ' + response.status,
+          );
+        }
+
+        const payload = (await response.json()) as Record<string, unknown>;
+        if (currentQueryRef.current !== trimmed) {
+          return false;
+        }
+
+        applySafeSearchState(
+          createSafeSearchState({
+            data: sanitizeSearchResults(payload.results),
+            normalizedQuery:
+              typeof payload.normalizedQuery === 'string'
+                ? payload.normalizedQuery
+                : '',
+            isLoading: false,
+            hasError: false,
+            totalSources:
+              totalSources > 0 ? totalSources : Math.max(completedSourceCount, 1),
+            completedSources:
+              totalSources > 0 ? totalSources : Math.max(completedSourceCount, 1),
+          }),
+        );
+        return true;
+      } catch (error) {
+        console.error('canonical search request failed:', error);
+        return false;
+      }
+    };
+
     const markSearchFailed = () => {
       flushPendingResults();
       applySafeSearchState(
@@ -754,15 +802,26 @@ function SearchPageClient() {
                 setCompletedSources((previous) => previous + 1);
                 break;
               case 'complete':
-                setCompletedSources(
-                  typeof payload.completedSources === 'number' &&
+                {
+                  const completedSourceCount =
+                    typeof payload.completedSources === 'number' &&
                     Number.isFinite(payload.completedSources)
-                    ? payload.completedSources
-                    : totalSources,
-                );
-                flushPendingResults();
-                setIsLoading(false);
-                setHasSearchError(false);
+                      ? payload.completedSources
+                      : totalSources;
+
+                  setCompletedSources(completedSourceCount);
+                  flushPendingResults();
+
+                  void (async () => {
+                    const synced = await fetchCanonicalSearchResults(
+                      completedSourceCount,
+                    );
+                    if (!synced && currentQueryRef.current === trimmed) {
+                      setIsLoading(false);
+                      setHasSearchError(false);
+                    }
+                  })();
+                }
                 try {
                   es.close();
                 } catch {}
@@ -996,6 +1055,11 @@ function SearchPageClient() {
               <div className='mb-4'>
                 <h2 className='text-xl font-bold text-gray-800 dark:text-gray-200'>
                   搜索结果
+                  <span className='ml-2 text-sm font-normal text-gray-500 dark:text-gray-400'>
+                    {viewMode === 'agg'
+                      ? `当前展示 ${displayedResultCount} 组 / 原始 ${searchResults.length} 条`
+                      : `当前展示 ${displayedResultCount} 条 / 原始 ${searchResults.length} 条`}
+                  </span>
                   {totalSources > 0 && useFluidSearch && (
                     <span className='ml-2 text-sm font-normal text-gray-500 dark:text-gray-400'>
                       {completedSources}/{totalSources}
@@ -1078,7 +1142,12 @@ function SearchPageClient() {
                   {viewMode === 'agg' ? (
                     Array.isArray(filteredAggResults) ? (
                       <VirtualizedVideoGrid
-                        mode='auto'
+                        // The search page currently scrolls with document.body,
+                        // which can break window-scroll virtualization and make
+                        // only the first screenful of cards appear reachable.
+                        // Prefer full rendering here until the scroll container
+                        // is wired to Virtuoso correctly.
+                        mode='never'
                         data={filteredAggResults}
                         virtualizationThreshold={240}
                         overscan={640}
@@ -1133,7 +1202,9 @@ function SearchPageClient() {
                     )
                   ) : Array.isArray(filteredAllResults) ? (
                     <VirtualizedVideoGrid
-                      mode='auto'
+                      // See the aggregate grid note above. Disable virtualization
+                      // on the search page so all matched results remain reachable.
+                      mode='never'
                       data={filteredAllResults}
                       virtualizationThreshold={240}
                       overscan={640}


### PR DESCRIPTION
## 变更说明

这个 PR 修复了两个彼此相关的搜索/播放问题：

1. 播放页在二次匹配搜索结果时，对 `year=unknown` 处理过严，导致部分本来可播放的结果被错误过滤，页面提示“未找到匹配结果”。
2. 搜索页前端展示结果与实际搜索结果不一致，容易表现为页面只能看到前面一小部分结果，同时无法直观看到真实结果总数。

## 修复内容

### 1. 修复播放页年份匹配

- 对播放页匹配阶段的年份字段做统一归一化处理
- 将 `unknown`、`0`、空字符串、`null`、`undefined` 等值视为“无有效年份限制”
- 当请求年份本身无有效约束时，不再因为年份字段把结果错误过滤掉
- 保持标题匹配和影视类型匹配逻辑不变

### 2. 修复搜索页结果展示

- 流式搜索完成后，再用普通 `/api/search` 结果做一次最终同步，避免页面展示结果与最终搜索结果不一致
- 在搜索页标题区域增加结果统计文案，明确区分“当前展示数量”和“原始结果数量”
- 暂时关闭搜索页上的虚拟列表渲染，避免在当前滚动容器实现下只显示前一小部分结果、后续结果无法继续浏览的问题

## 影响范围

- 播放页仅影响搜索结果的二次筛选逻辑
- 搜索页仅影响结果展示与数量统计，不修改搜索接口协议

## 验证情况

- 已基于修复后的代码重新构建本地测试环境
- 已确认 `year=unknown` 场景下，原本会被误过滤的可播放结果现在可以正常进入播放页
- 已确认搜索页可以正确显示原始结果总数，并且结果列表不再只停留在前一小部分
