### PR TITLE
feat(proxy): add m3u8 ad-segment filter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,10 +65,16 @@ FFMPEG_DOWNLOAD_DIR=.cache/ffmpeg-downloads
 FFMPEG_MAX_CONCURRENT_JOBS=2
 FFMPEG_JOB_RETENTION_MS=86400000
 
-# M3U8 广告分段过滤（在 /api/detail 返回的 episodes URL 上自动应用）
+# M3U8 广告分段过滤（在 /api/detail、/api/search 等返回的 episodes URL 上自动改写）
+# 优先级：管理后台 AdFilterConfig.enabled > 此环境变量 > 默认开
 # 'true' / '1' = 开（默认），'false' / '0' = 关
-# 客户端可通过 /api/detail?...&adfilter=false 临时禁用
+# 客户端可通过 ?adfilter=false 在 URL 上临时禁用（用于调试/对照原始时间轴）
 ENABLE_AD_FILTER=true
+
+# 高级阈值（一般不用改，UI 不暴露；改坏可能误删正片）
+# AD_FILTER_MIN_DURATION=3       # 广告段最短时长（秒）
+# AD_FILTER_MAX_DURATION=120     # 广告段最长时长（秒），超过此值的 group 永远不被判为广告
+# AD_FILTER_MAX_SEGMENTS=15      # 单个 discontinuity group 最多包含多少个 segment 才可能被判为广告
 
 # Development
 NODE_ENV=development

--- a/.env.example
+++ b/.env.example
@@ -65,5 +65,10 @@ FFMPEG_DOWNLOAD_DIR=.cache/ffmpeg-downloads
 FFMPEG_MAX_CONCURRENT_JOBS=2
 FFMPEG_JOB_RETENTION_MS=86400000
 
+# M3U8 广告分段过滤（在 /api/detail 返回的 episodes URL 上自动应用）
+# 'true' / '1' = 开（默认），'false' / '0' = 关
+# 客户端可通过 /api/detail?...&adfilter=false 临时禁用
+ENABLE_AD_FILTER=true
+
 # Development
 NODE_ENV=development

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,15 +43,14 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v5
 
-      - name: Validate built-in dandanplay credentials
+      - name: Check built-in dandanplay credentials
         if: github.event_name != 'pull_request'
         env:
           DANDANPLAY_APP_ID: ${{ secrets.DANDANPLAY_APP_ID }}
           DANDANPLAY_APP_SECRET: ${{ secrets.DANDANPLAY_APP_SECRET }}
         run: |
           if [ -z "$DANDANPLAY_APP_ID" ] || [ -z "$DANDANPLAY_APP_SECRET" ]; then
-            echo "::error::DANDANPLAY_APP_ID or DANDANPLAY_APP_SECRET is empty. Official image requires built-in dandanplay credentials."
-            exit 1
+            echo "::warning::DANDANPLAY_APP_ID/DANDANPLAY_APP_SECRET not set; image will be built without built-in 弹弹play credentials."
           fi
 
       - name: Set up Docker Buildx

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -371,6 +371,7 @@ interface DataSource {
   detail?: string;
   disabled?: boolean;
   is_adult?: boolean; // 标记是否为成人资源
+  disable_ad_filter?: boolean; // 该源不走 m3u8 广告过滤代理
   from: 'config' | 'custom';
 }
 
@@ -2846,6 +2847,23 @@ const VideoSourceConfig = ({
     });
   };
 
+  // 切换该源是否走 m3u8 广告过滤代理（disable_ad_filter=true 时该源直连上游，跳过过滤）
+  const handleToggleAdFilter = (key: string) => {
+    const target = sources.find((s) => s.key === key);
+    if (!target) return;
+    const newDisable = !target.disable_ad_filter;
+
+    withLoading(`toggleAdFilter_${key}`, () =>
+      callSourceApi({
+        action: 'update_ad_filter',
+        key,
+        disable_ad_filter: newDisable,
+      }),
+    ).catch(() => {
+      console.error('切换广告过滤豁免失败', key);
+    });
+  };
+
   const handleDelete = (key: string) => {
     const target = sources.find((s) => s.key === key);
     if (!target) return;
@@ -3533,6 +3551,32 @@ const VideoSourceConfig = ({
             />
           </button>
         </td>
+        <td className='px-6 py-4 whitespace-nowrap text-center'>
+          <button
+            onClick={() => handleToggleAdFilter(source.key)}
+            disabled={isLoading(`toggleAdFilter_${source.key}`)}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus:outline-none ${
+              !source.disable_ad_filter
+                ? buttonStyles.toggleOn
+                : buttonStyles.toggleOff
+            } ${
+              isLoading(`toggleAdFilter_${source.key}`)
+                ? 'opacity-50 cursor-not-allowed'
+                : 'cursor-pointer hover:opacity-80'
+            }`}
+            title={
+              source.disable_ad_filter
+                ? '已豁免：该源直连上游，不删广告段'
+                : '已启用：通过 m3u8 过滤代理删除广告段'
+            }
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                !source.disable_ad_filter ? 'translate-x-5' : 'translate-x-0.5'
+              }`}
+            />
+          </button>
+        </td>
         <td className='px-6 py-4 whitespace-nowrap max-w-4'>
           {(() => {
             const status = getValidationStatus(source.key);
@@ -4133,6 +4177,12 @@ const VideoSourceConfig = ({
                 </th>
                 <th className='px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider'>
                   成人资源
+                </th>
+                <th
+                  className='px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider'
+                  title='关闭后该源将跳过 m3u8 广告过滤代理，直连上游'
+                >
+                  广告过滤
                 </th>
                 <th className='px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider'>
                   有效性
@@ -5144,6 +5194,10 @@ const SiteConfigComponent = ({
     LoginBackground: 'https://pan.yyds.nyc.mn/background.png',
   });
 
+  // 广告过滤总开关（独立于 SiteConfig，立即保存到 /api/admin/adfilter）
+  const [adFilterEnabled, setAdFilterEnabled] = useState(true);
+  const [adFilterSaving, setAdFilterSaving] = useState(false);
+
   // 豆瓣数据源相关状态
   const [isDoubanDropdownOpen, setIsDoubanDropdownOpen] = useState(false);
   const [isDoubanImageProxyDropdownOpen, setIsDoubanImageProxyDropdownOpen] =
@@ -5214,7 +5268,35 @@ const SiteConfigComponent = ({
           'https://pan.yyds.nyc.mn/background.png',
       });
     }
+    if (config?.AdFilterConfig) {
+      setAdFilterEnabled(config.AdFilterConfig.enabled ?? true);
+    }
   }, [config]);
+
+  // 切换广告过滤总开关，立即调用 /api/admin/adfilter 保存
+  const handleToggleAdFilterGlobal = async () => {
+    if (adFilterSaving) return;
+    const next = !adFilterEnabled;
+    setAdFilterEnabled(next); // 乐观更新
+    setAdFilterSaving(true);
+    try {
+      const resp = await fetch('/api/admin/adfilter', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!resp.ok) {
+        setAdFilterEnabled(!next); // 失败回滚
+        const err = await resp.json().catch(() => null);
+        showError(err?.error || '保存广告过滤开关失败');
+      }
+    } catch (e) {
+      setAdFilterEnabled(!next);
+      showError(e instanceof Error ? e.message : '保存广告过滤开关失败');
+    } finally {
+      setAdFilterSaving(false);
+    }
+  };
 
   // 点击外部区域关闭下拉框
   useEffect(() => {
@@ -5767,6 +5849,39 @@ const SiteConfigComponent = ({
         </div>
         <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
           启用后搜索结果将实时流式返回，提升用户体验。
+        </p>
+      </div>
+
+      {/* 广告过滤总开关（独立于其他 SiteConfig，立即保存） */}
+      <div>
+        <div className='flex items-center justify-between'>
+          <label className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'>
+            启用 m3u8 广告过滤
+          </label>
+          <button
+            type='button'
+            onClick={handleToggleAdFilterGlobal}
+            disabled={adFilterSaving}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 ${
+              adFilterEnabled
+                ? buttonStyles.toggleOn
+                : buttonStyles.toggleOff
+            } ${adFilterSaving ? 'opacity-50 cursor-not-allowed' : ''}`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full ${
+                buttonStyles.toggleThumb
+              } transition-transform ${
+                adFilterEnabled
+                  ? buttonStyles.toggleThumbOn
+                  : buttonStyles.toggleThumbOff
+              }`}
+            />
+          </button>
+        </div>
+        <p className='mt-1 text-xs text-gray-500 dark:text-gray-400'>
+          自动识别并删除 CMS 资源站 m3u8 中由 #EXT-X-DISCONTINUITY 拼接的广告分段。
+          关掉后所有源直连上游，不再走过滤代理。可在视频源列表里对单个源单独豁免。
         </p>
       </div>
 

--- a/src/app/api/admin/adfilter/route.ts
+++ b/src/app/api/admin/adfilter/route.ts
@@ -1,0 +1,65 @@
+/* eslint-disable no-console */
+
+import { NextRequest, NextResponse } from 'next/server';
+
+import { persistAdminConfigMutation } from '@/lib/admin-config-mutation';
+import { verifyApiAuth } from '@/lib/auth';
+import { getConfig, getLocalModeConfig } from '@/lib/config';
+
+export const runtime = 'nodejs';
+
+interface AdFilterPayload {
+  enabled?: boolean;
+}
+
+export async function POST(request: NextRequest) {
+  const authResult = verifyApiAuth(request);
+
+  try {
+    const body = (await request.json()) as AdFilterPayload;
+    const enabled = body.enabled !== false; // 默认开
+
+    if (authResult.isLocalMode) {
+      const localConfig = getLocalModeConfig();
+      localConfig.AdFilterConfig = { enabled };
+      return NextResponse.json({
+        message: '广告过滤配置更新成功（本地模式）',
+        storageMode: 'local',
+      });
+    }
+
+    if (!authResult.isValid) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const username = authResult.username;
+    const adminConfig = await getConfig();
+
+    if (username !== process.env.USERNAME) {
+      const user = adminConfig.UserConfig.Users.find(
+        (item) => item.username === username,
+      );
+      if (!user || user.role !== 'admin' || user.banned) {
+        return NextResponse.json({ error: '权限不足' }, { status: 401 });
+      }
+    }
+
+    adminConfig.AdFilterConfig = { enabled };
+
+    await persistAdminConfigMutation(adminConfig);
+
+    return NextResponse.json(
+      { ok: true },
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  } catch (error) {
+    console.error('更新广告过滤配置失败:', error);
+    return NextResponse.json(
+      {
+        error: '更新广告过滤配置失败',
+        details: (error as Error).message,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/source/route.ts
+++ b/src/app/api/admin/source/route.ts
@@ -18,7 +18,8 @@ type Action =
   | 'batch_disable'
   | 'batch_enable'
   | 'batch_delete'
-  | 'update_adult';
+  | 'update_adult'
+  | 'update_ad_filter';
 
 interface BaseBody {
   action?: Action;
@@ -69,6 +70,7 @@ export async function POST(request: NextRequest) {
       'batch_enable',
       'batch_delete',
       'update_adult',
+      'update_ad_filter',
     ];
     if (!action || !ACTIONS.includes(action)) {
       return NextResponse.json({ error: '参数格式错误' }, { status: 400 });
@@ -141,6 +143,19 @@ export async function POST(request: NextRequest) {
         if (!entry)
           return NextResponse.json({ error: '源不存在' }, { status: 404 });
         entry.is_adult = is_adult || false;
+        break;
+      }
+      case 'update_ad_filter': {
+        const { key, disable_ad_filter } = body as {
+          key?: string;
+          disable_ad_filter?: boolean;
+        };
+        if (!key)
+          return NextResponse.json({ error: '缺少 key 参数' }, { status: 400 });
+        const entry = adminConfig.SourceConfig.find((s) => s.key === key);
+        if (!entry)
+          return NextResponse.json({ error: '源不存在' }, { status: 404 });
+        entry.disable_ad_filter = !!disable_ad_filter;
         break;
       }
       case 'delete': {

--- a/src/app/api/detail/route.ts
+++ b/src/app/api/detail/route.ts
@@ -17,6 +17,52 @@ import { SearchResult } from '@/lib/types';
 
 export const runtime = 'nodejs';
 
+function isAdFilterEnabled(): boolean {
+  const flag = process.env.ENABLE_AD_FILTER;
+  if (flag === undefined) return true; // 默认开
+  return flag === 'true' || flag === '1';
+}
+
+function adFilterDisabledByQuery(request: NextRequest): boolean {
+  const v = request.nextUrl.searchParams.get('adfilter');
+  return v === 'false' || v === '0';
+}
+
+function buildFilterProxyUrl(request: NextRequest, upstreamUrl: string): string {
+  const host = request.headers.get('host');
+  const protocol =
+    request.headers.get('x-forwarded-proto') ||
+    request.nextUrl.protocol.replace(':', '') ||
+    'http';
+  return `${protocol}://${host}/api/proxy/m3u8-filter?url=${encodeURIComponent(
+    upstreamUrl,
+  )}`;
+}
+
+function shouldRewriteEpisode(url: string): boolean {
+  if (!url) return false;
+  if (!/^https?:\/\//i.test(url)) return false; // 跳过 /api/private-library/stream 这类内部路径
+  if (!/\.m3u8(\?|$|#)/i.test(url)) return false; // 只处理 m3u8
+  return true;
+}
+
+function maybeRewriteEpisodesForAdFilter(
+  result: SearchResult,
+  request: NextRequest,
+): SearchResult {
+  if (!isAdFilterEnabled() || adFilterDisabledByQuery(request)) return result;
+  if (result.source === 'private_library') return result;
+  if (!Array.isArray(result.episodes) || result.episodes.length === 0) {
+    return result;
+  }
+
+  const rewritten = result.episodes.map((ep) =>
+    shouldRewriteEpisode(ep) ? buildFilterProxyUrl(request, ep) : ep,
+  );
+
+  return { ...result, episodes: rewritten };
+}
+
 export async function GET(request: NextRequest) {
   const authResult = verifyApiAuth(request);
   if (!authResult.isValid) {
@@ -165,7 +211,9 @@ export async function GET(request: NextRequest) {
     const result = await getDetailFromApi(apiSite, id);
     const cacheTime = await getCacheTime();
 
-    return NextResponse.json(result, {
+    const finalResult = maybeRewriteEpisodesForAdFilter(result, request);
+
+    return NextResponse.json(finalResult, {
       headers: {
         'Cache-Control': `public, max-age=${cacheTime}, s-maxage=${cacheTime}`,
         'CDN-Cache-Control': `public, s-maxage=${cacheTime}`,

--- a/src/app/api/detail/route.ts
+++ b/src/app/api/detail/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getAuthInfoFromCookie, verifyApiAuth } from '@/lib/auth';
 import { getAvailableApiSites, getCacheTime } from '@/lib/config';
 import { getDetailFromApi } from '@/lib/downstream';
+import { rewriteEpisodesForAdFilter } from '@/lib/episode-rewriter';
 import {
   buildPrivateLibraryPosterUrl,
   formatPrivateLibrarySourceName,
@@ -16,52 +17,6 @@ import {
 import { SearchResult } from '@/lib/types';
 
 export const runtime = 'nodejs';
-
-function isAdFilterEnabled(): boolean {
-  const flag = process.env.ENABLE_AD_FILTER;
-  if (flag === undefined) return true; // 默认开
-  return flag === 'true' || flag === '1';
-}
-
-function adFilterDisabledByQuery(request: NextRequest): boolean {
-  const v = request.nextUrl.searchParams.get('adfilter');
-  return v === 'false' || v === '0';
-}
-
-function buildFilterProxyUrl(request: NextRequest, upstreamUrl: string): string {
-  const host = request.headers.get('host');
-  const protocol =
-    request.headers.get('x-forwarded-proto') ||
-    request.nextUrl.protocol.replace(':', '') ||
-    'http';
-  return `${protocol}://${host}/api/proxy/m3u8-filter?url=${encodeURIComponent(
-    upstreamUrl,
-  )}`;
-}
-
-function shouldRewriteEpisode(url: string): boolean {
-  if (!url) return false;
-  if (!/^https?:\/\//i.test(url)) return false; // 跳过 /api/private-library/stream 这类内部路径
-  if (!/\.m3u8(\?|$|#)/i.test(url)) return false; // 只处理 m3u8
-  return true;
-}
-
-function maybeRewriteEpisodesForAdFilter(
-  result: SearchResult,
-  request: NextRequest,
-): SearchResult {
-  if (!isAdFilterEnabled() || adFilterDisabledByQuery(request)) return result;
-  if (result.source === 'private_library') return result;
-  if (!Array.isArray(result.episodes) || result.episodes.length === 0) {
-    return result;
-  }
-
-  const rewritten = result.episodes.map((ep) =>
-    shouldRewriteEpisode(ep) ? buildFilterProxyUrl(request, ep) : ep,
-  );
-
-  return { ...result, episodes: rewritten };
-}
 
 export async function GET(request: NextRequest) {
   const authResult = verifyApiAuth(request);
@@ -211,7 +166,7 @@ export async function GET(request: NextRequest) {
     const result = await getDetailFromApi(apiSite, id);
     const cacheTime = await getCacheTime();
 
-    const finalResult = maybeRewriteEpisodesForAdFilter(result, request);
+    const finalResult = rewriteEpisodesForAdFilter(result, request);
 
     return NextResponse.json(finalResult, {
       headers: {

--- a/src/app/api/detail/route.ts
+++ b/src/app/api/detail/route.ts
@@ -166,7 +166,7 @@ export async function GET(request: NextRequest) {
     const result = await getDetailFromApi(apiSite, id);
     const cacheTime = await getCacheTime();
 
-    const finalResult = rewriteEpisodesForAdFilter(result, request);
+    const finalResult = await rewriteEpisodesForAdFilter(result, request);
 
     return NextResponse.json(finalResult, {
       headers: {

--- a/src/app/api/proxy/m3u8-filter/route.ts
+++ b/src/app/api/proxy/m3u8-filter/route.ts
@@ -2,7 +2,8 @@
 
 import { NextResponse } from 'next/server';
 
-import { filterM3U8 } from '@/lib/ad-filter';
+import { DEFAULT_AD_FILTER_CONFIG, filterM3U8 } from '@/lib/ad-filter';
+import { getConfig } from '@/lib/config';
 import { getBaseUrl, resolveUrl } from '@/lib/live';
 
 export const runtime = 'nodejs';
@@ -13,10 +14,49 @@ const DEFAULT_UA =
 
 const FETCH_TIMEOUT_MS = 8000;
 
-function isAdFilterEnabled(): boolean {
+/**
+ * 解析广告过滤是否启用：admin 后台开关 > 环境变量 > 默认开。
+ * 后台未配置时回落到 ENABLE_AD_FILTER；都没配置时默认 true。
+ */
+async function isAdFilterEnabled(): Promise<boolean> {
+  try {
+    const cfg = await getConfig();
+    if (typeof cfg?.AdFilterConfig?.enabled === 'boolean') {
+      return cfg.AdFilterConfig.enabled;
+    }
+  } catch {
+    // ignore - fallback to env
+  }
   const flag = process.env.ENABLE_AD_FILTER;
-  if (flag === undefined) return true; // 默认开
+  if (flag === undefined) return true;
   return flag === 'true' || flag === '1';
+}
+
+/**
+ * 高级用户可通过环境变量重载广告判定阈值（不在管理 UI 暴露）：
+ *   AD_FILTER_MIN_DURATION  / AD_FILTER_MAX_DURATION  / AD_FILTER_MAX_SEGMENTS
+ */
+function buildFilterConfigFromEnv() {
+  const parseNum = (v: string | undefined, fallback: number): number => {
+    if (!v) return fallback;
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+  };
+  return {
+    ...DEFAULT_AD_FILTER_CONFIG,
+    minAdDuration: parseNum(
+      process.env.AD_FILTER_MIN_DURATION,
+      DEFAULT_AD_FILTER_CONFIG.minAdDuration,
+    ),
+    maxAdDuration: parseNum(
+      process.env.AD_FILTER_MAX_DURATION,
+      DEFAULT_AD_FILTER_CONFIG.maxAdDuration,
+    ),
+    maxConsecutiveAdSegments: parseNum(
+      process.env.AD_FILTER_MAX_SEGMENTS,
+      DEFAULT_AD_FILTER_CONFIG.maxConsecutiveAdSegments,
+    ),
+  };
 }
 
 function buildProxyUrl(
@@ -206,8 +246,8 @@ export async function GET(request: Request) {
     const queryDisable =
       searchParams.get('adfilter') === 'false' ||
       searchParams.get('adfilter') === '0';
-    if (isAdFilterEnabled() && !queryDisable) {
-      const result = filterM3U8(absolute);
+    if ((await isAdFilterEnabled()) && !queryDisable) {
+      const result = filterM3U8(absolute, buildFilterConfigFromEnv());
       body = result.filtered;
       adsRemoved = result.adsRemoved;
       adsDuration = result.adsDuration;

--- a/src/app/api/proxy/m3u8-filter/route.ts
+++ b/src/app/api/proxy/m3u8-filter/route.ts
@@ -1,0 +1,213 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { NextResponse } from 'next/server';
+
+import { filterM3U8 } from '@/lib/ad-filter';
+import { getBaseUrl, resolveUrl } from '@/lib/live';
+
+export const runtime = 'nodejs';
+
+const DEFAULT_UA =
+  'Mozilla/5.0 (Linux; Android 10; AndroidTV) AppleWebKit/537.36 ' +
+  '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+const FETCH_TIMEOUT_MS = 8000;
+
+function isAdFilterEnabled(): boolean {
+  const flag = process.env.ENABLE_AD_FILTER;
+  if (flag === undefined) return true; // 默认开
+  return flag === 'true' || flag === '1';
+}
+
+function buildProxyUrl(request: Request, upstreamUrl: string): string {
+  const referer = request.headers.get('referer');
+  let protocol = 'http';
+  if (referer) {
+    try {
+      protocol = new URL(referer).protocol.replace(':', '');
+    } catch {
+      // ignore
+    }
+  }
+  const host = request.headers.get('host');
+  return `${protocol}://${host}/api/proxy/m3u8-filter?url=${encodeURIComponent(
+    upstreamUrl,
+  )}`;
+}
+
+/**
+ * 主播放列表（含 #EXT-X-STREAM-INF）：把每个变体 URL 改写为再次走本路由，
+ * 这样客户端最终拿到的变体也会被过滤。
+ */
+function rewriteMasterPlaylist(
+  content: string,
+  baseUrl: string,
+  request: Request,
+): string {
+  const lines = content.split('\n');
+  const out: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    out.push(line);
+
+    if (line.trim().startsWith('#EXT-X-STREAM-INF:')) {
+      // 下一行是变体 URL
+      if (i + 1 < lines.length) {
+        const variantLine = lines[i + 1].trim();
+        if (variantLine && !variantLine.startsWith('#')) {
+          const absolute = resolveUrl(baseUrl, variantLine);
+          out.push(buildProxyUrl(request, absolute));
+          i++;
+          continue;
+        }
+      }
+    }
+  }
+
+  return out.join('\n');
+}
+
+/**
+ * 变体播放列表：把所有相对 URL 解析为上游绝对 URL，让播放器直连上游 CDN
+ * 拉 TS（不消耗本服务带宽）。EXT-X-MAP/EXT-X-KEY 同样处理。
+ */
+function absolutizeVariantPlaylist(content: string, baseUrl: string): string {
+  const lines = content.split('\n');
+
+  return lines
+    .map((rawLine) => {
+      const line = rawLine.trimEnd();
+
+      if (line.startsWith('#EXT-X-MAP:') || line.startsWith('#EXT-X-KEY:')) {
+        return line.replace(/URI="([^"]+)"/, (_, uri) => {
+          return `URI="${resolveUrl(baseUrl, uri)}"`;
+        });
+      }
+
+      if (line && !line.startsWith('#')) {
+        return resolveUrl(baseUrl, line);
+      }
+
+      return line;
+    })
+    .join('\n');
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const url = searchParams.get('url');
+
+  if (!url) {
+    return NextResponse.json({ error: 'Missing url' }, { status: 400 });
+  }
+
+  let decodedUrl: string;
+  try {
+    decodedUrl = decodeURIComponent(url);
+  } catch {
+    return NextResponse.json({ error: 'Invalid url' }, { status: 400 });
+  }
+
+  if (!/^https?:\/\//i.test(decodedUrl)) {
+    return NextResponse.json(
+      { error: 'Only http/https supported' },
+      { status: 400 },
+    );
+  }
+
+  const ua = request.headers.get('user-agent') || DEFAULT_UA;
+
+  let upstream: Response;
+  try {
+    upstream = await fetchWithTimeout(
+      decodedUrl,
+      {
+        cache: 'no-store',
+        redirect: 'follow',
+        headers: { 'User-Agent': ua },
+      },
+      FETCH_TIMEOUT_MS,
+    );
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: 'Upstream fetch failed', details: e?.message || 'unknown' },
+      { status: 502 },
+    );
+  }
+
+  if (!upstream.ok) {
+    return NextResponse.json(
+      { error: 'Upstream returned non-OK', status: upstream.status },
+      { status: 502 },
+    );
+  }
+
+  const content = await upstream.text();
+  // 跟随重定向后实际拿到内容的 URL，作为相对路径解析的 baseUrl
+  const finalUrl = upstream.url || decodedUrl;
+  const baseUrl = getBaseUrl(finalUrl);
+
+  let body: string;
+  let adsRemoved = 0;
+  let adsDuration = 0;
+
+  if (content.includes('#EXT-X-STREAM-INF')) {
+    body = rewriteMasterPlaylist(content, baseUrl, request);
+  } else {
+    const absolute = absolutizeVariantPlaylist(content, baseUrl);
+    if (isAdFilterEnabled()) {
+      const result = filterM3U8(absolute);
+      body = result.filtered;
+      adsRemoved = result.adsRemoved;
+      adsDuration = result.adsDuration;
+    } else {
+      body = absolute;
+    }
+  }
+
+  const headers = new Headers();
+  headers.set(
+    'Content-Type',
+    upstream.headers.get('Content-Type') || 'application/vnd.apple.mpegurl',
+  );
+  headers.set('Cache-Control', 'no-cache');
+  headers.set('Access-Control-Allow-Origin', '*');
+  headers.set('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  headers.set('Access-Control-Allow-Headers', 'Content-Type, Range, Accept');
+  headers.set(
+    'Access-Control-Expose-Headers',
+    'Content-Length, Content-Range, X-Ads-Removed, X-Ads-Duration',
+  );
+  if (adsRemoved > 0) {
+    headers.set('X-Ads-Removed', String(adsRemoved));
+    headers.set('X-Ads-Duration', adsDuration.toFixed(1));
+  }
+
+  return new Response(body, { status: 200, headers });
+}
+
+export async function OPTIONS() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Range, Accept',
+    },
+  });
+}

--- a/src/app/api/proxy/m3u8-filter/route.ts
+++ b/src/app/api/proxy/m3u8-filter/route.ts
@@ -201,7 +201,12 @@ export async function GET(request: Request) {
     body = rewriteMasterPlaylist(content, baseUrl, request, refererToSend);
   } else {
     const absolute = absolutizeVariantPlaylist(content, baseUrl);
-    if (isAdFilterEnabled()) {
+    // 调试/对照场景：?adfilter=false 让代理只做 referer 透传 + 相对路径绝对化，
+    // 不删任何广告段，方便客户端拿到原始时间轴
+    const queryDisable =
+      searchParams.get('adfilter') === 'false' ||
+      searchParams.get('adfilter') === '0';
+    if (isAdFilterEnabled() && !queryDisable) {
       const result = filterM3U8(absolute);
       body = result.filtered;
       adsRemoved = result.adsRemoved;

--- a/src/app/api/proxy/m3u8-filter/route.ts
+++ b/src/app/api/proxy/m3u8-filter/route.ts
@@ -19,20 +19,24 @@ function isAdFilterEnabled(): boolean {
   return flag === 'true' || flag === '1';
 }
 
-function buildProxyUrl(request: Request, upstreamUrl: string): string {
-  const referer = request.headers.get('referer');
-  let protocol = 'http';
-  if (referer) {
-    try {
-      protocol = new URL(referer).protocol.replace(':', '');
-    } catch {
-      // ignore
-    }
-  }
+function buildProxyUrl(
+  request: Request,
+  upstreamUrl: string,
+  referer?: string,
+): string {
   const host = request.headers.get('host');
-  return `${protocol}://${host}/api/proxy/m3u8-filter?url=${encodeURIComponent(
-    upstreamUrl,
-  )}`;
+  const protocol =
+    request.headers.get('x-forwarded-proto') ||
+    (() => {
+      try {
+        return new URL(request.url).protocol.replace(':', '');
+      } catch {
+        return 'http';
+      }
+    })();
+  let qs = `url=${encodeURIComponent(upstreamUrl)}`;
+  if (referer) qs += `&referer=${encodeURIComponent(referer)}`;
+  return `${protocol}://${host}/api/proxy/m3u8-filter?${qs}`;
 }
 
 /**
@@ -43,6 +47,7 @@ function rewriteMasterPlaylist(
   content: string,
   baseUrl: string,
   request: Request,
+  referer?: string,
 ): string {
   const lines = content.split('\n');
   const out: string[] = [];
@@ -57,7 +62,7 @@ function rewriteMasterPlaylist(
         const variantLine = lines[i + 1].trim();
         if (variantLine && !variantLine.startsWith('#')) {
           const absolute = resolveUrl(baseUrl, variantLine);
-          out.push(buildProxyUrl(request, absolute));
+          out.push(buildProxyUrl(request, absolute, referer));
           i++;
           continue;
         }
@@ -132,6 +137,30 @@ export async function GET(request: Request) {
 
   const ua = request.headers.get('user-agent') || DEFAULT_UA;
 
+  // 上游资源站常按 Referer/Origin 做白名单校验。优先级：
+  //   1. URL 显式参数 ?referer=...（客户端已知最准确的来源）
+  //   2. 入站请求自带的 Referer（浏览器自然发出的）
+  //   3. 上游 URL 自身的 origin 作为兜底（很多源站允许同源 Referer）
+  const explicitReferer = searchParams.get('referer') || undefined;
+  const inboundReferer = request.headers.get('referer') || undefined;
+  let fallbackReferer: string | undefined;
+  try {
+    fallbackReferer = new URL(decodedUrl).origin + '/';
+  } catch {
+    fallbackReferer = undefined;
+  }
+  const refererToSend = explicitReferer || inboundReferer || fallbackReferer;
+
+  const upstreamHeaders: Record<string, string> = { 'User-Agent': ua };
+  if (refererToSend) {
+    upstreamHeaders['Referer'] = refererToSend;
+    try {
+      upstreamHeaders['Origin'] = new URL(refererToSend).origin;
+    } catch {
+      // ignore
+    }
+  }
+
   let upstream: Response;
   try {
     upstream = await fetchWithTimeout(
@@ -139,7 +168,7 @@ export async function GET(request: Request) {
       {
         cache: 'no-store',
         redirect: 'follow',
-        headers: { 'User-Agent': ua },
+        headers: upstreamHeaders,
       },
       FETCH_TIMEOUT_MS,
     );
@@ -167,7 +196,9 @@ export async function GET(request: Request) {
   let adsDuration = 0;
 
   if (content.includes('#EXT-X-STREAM-INF')) {
-    body = rewriteMasterPlaylist(content, baseUrl, request);
+    // 把当前请求用的 referer 透传到变体 URL 的代理参数里，
+    // 否则下一跳又会因为没有 Referer 被上游拒
+    body = rewriteMasterPlaylist(content, baseUrl, request, refererToSend);
   } else {
     const absolute = absolutizeVariantPlaylist(content, baseUrl);
     if (isAdFilterEnabled()) {

--- a/src/app/api/search/one/route.ts
+++ b/src/app/api/search/one/route.ts
@@ -105,7 +105,7 @@ export async function GET(request: NextRequest) {
         },
       );
     } else {
-      const rewritten = rewriteEpisodesForAdFilterMany(result, request);
+      const rewritten = await rewriteEpisodesForAdFilterMany(result, request);
       return NextResponse.json(
         { results: rewritten },
         {

--- a/src/app/api/search/one/route.ts
+++ b/src/app/api/search/one/route.ts
@@ -4,6 +4,7 @@ import { resolveAdultFilter } from '@/lib/adult-filter';
 import { getAuthInfoFromCookie, verifyApiAuth } from '@/lib/auth';
 import { getAvailableApiSites, getCacheTime, getConfig } from '@/lib/config';
 import { searchFromApi } from '@/lib/downstream';
+import { rewriteEpisodesForAdFilterMany } from '@/lib/episode-rewriter';
 import { yellowWords } from '@/lib/yellow';
 
 export const runtime = 'nodejs';
@@ -104,8 +105,9 @@ export async function GET(request: NextRequest) {
         },
       );
     } else {
+      const rewritten = rewriteEpisodesForAdFilterMany(result, request);
       return NextResponse.json(
-        { results: result },
+        { results: rewritten },
         {
           headers: {
             'Cache-Control': `public, max-age=${cacheTime}, s-maxage=${cacheTime}`,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -145,7 +145,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ results: [] }, { status: 200 });
     }
 
-    const rewrittenResults = rewriteEpisodesForAdFilterMany(
+    const rewrittenResults = await rewriteEpisodesForAdFilterMany(
       flattenedResults,
       request,
     );

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -6,6 +6,7 @@ import { getAuthInfoFromCookie, verifyApiAuth } from '@/lib/auth';
 import { toSimplified } from '@/lib/chinese';
 import { getAvailableApiSites, getCacheTime, getConfig } from '@/lib/config';
 import { searchFromApi } from '@/lib/downstream';
+import { rewriteEpisodesForAdFilterMany } from '@/lib/episode-rewriter';
 import { rankSearchResults } from '@/lib/search-ranking';
 import { yellowWords } from '@/lib/yellow';
 
@@ -144,8 +145,13 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ results: [] }, { status: 200 });
     }
 
+    const rewrittenResults = rewriteEpisodesForAdFilterMany(
+      flattenedResults,
+      request,
+    );
+
     return NextResponse.json(
-      { results: flattenedResults, normalizedQuery },
+      { results: rewrittenResults, normalizedQuery },
       {
         headers: {
           'Cache-Control': `public, max-age=${cacheTime}, s-maxage=${cacheTime}`,

--- a/src/app/api/search/ws/route.ts
+++ b/src/app/api/search/ws/route.ts
@@ -167,7 +167,7 @@ export async function GET(request: NextRequest) {
           completedSources++;
 
           if (!streamClosed) {
-            const rewrittenResults = rewriteEpisodesForAdFilterMany(
+            const rewrittenResults = await rewriteEpisodesForAdFilterMany(
               filteredResults,
               request,
             );

--- a/src/app/api/search/ws/route.ts
+++ b/src/app/api/search/ws/route.ts
@@ -6,6 +6,7 @@ import { getAuthInfoFromCookie, verifyApiAuth } from '@/lib/auth';
 import { toSimplified } from '@/lib/chinese';
 import { getAvailableApiSites, getConfig } from '@/lib/config';
 import { searchFromApi } from '@/lib/downstream';
+import { rewriteEpisodesForAdFilterMany } from '@/lib/episode-rewriter';
 import { rankSearchResults } from '@/lib/search-ranking';
 import { yellowWords } from '@/lib/yellow';
 
@@ -166,11 +167,15 @@ export async function GET(request: NextRequest) {
           completedSources++;
 
           if (!streamClosed) {
+            const rewrittenResults = rewriteEpisodesForAdFilterMany(
+              filteredResults,
+              request,
+            );
             const sourceEvent = `data: ${JSON.stringify({
               type: 'source_result',
               source: site.key,
               sourceName: site.name,
-              results: filteredResults,
+              results: rewrittenResults,
               timestamp: Date.now(),
             })}\n\n`;
 

--- a/src/lib/ad-filter.ts
+++ b/src/lib/ad-filter.ts
@@ -1,0 +1,393 @@
+/**
+ * M3U8 广告分段过滤
+ *
+ * 算法移植自 dongguatv 项目的 public/libs/js/ad-filter.js（v3.1）
+ * https://github.com/luoxiaohei/dongguatv
+ *
+ * 核心思路：CMS 资源站常通过 #EXT-X-DISCONTINUITY 在主内容前后/中间
+ * 拼接广告分段。识别"主内容组（最长的 discontinuity 组）"，将其余
+ * 时长在 3-120 秒、分段数较少的短组判定为广告并删除。
+ */
+
+export interface AdFilterConfig {
+  enabled: boolean;
+  minAdDuration: number;
+  maxAdDuration: number;
+  maxConsecutiveAdSegments: number;
+  adDomainPatterns: string[];
+  safeDomains: string[];
+}
+
+export const DEFAULT_AD_FILTER_CONFIG: AdFilterConfig = {
+  enabled: true,
+  minAdDuration: 3,
+  maxAdDuration: 120,
+  maxConsecutiveAdSegments: 15,
+  adDomainPatterns: [
+    'doubleclick',
+    'googlesyndication',
+    'googleadservices',
+    'adsystem',
+    'adservice',
+    'baidu.com/adm',
+    'pos.baidu.com',
+    'cpro.baidu',
+    'eclick.baidu',
+    'baidustatic.com/adm',
+    'gdt.qq.com',
+    'l.qq.com',
+    'e.qq.com',
+    'adsmind.gdtimg',
+    'tanx.com',
+    'alimama.com',
+    'mmstat.com',
+    'atanx.alicdn',
+    'ykad.',
+    'ykimg.com/material',
+    'iusmob.',
+    'pangle.',
+    'pangolin.',
+    'bytedance.com/ad',
+    'oceanengine.',
+    'csjad.',
+    'iqiyiad.',
+    'iqiyi.com/cupid',
+    'cupid.iqiyi',
+    'mgtvad.',
+    'admaster.',
+    'miaozhen.',
+    'adcdn.',
+    'ad-cdn.',
+    '/ad/',
+    '/ads/',
+    'advert',
+    'adsrv',
+    'adpush',
+    'adx.',
+    'dsp.',
+    'rtb.',
+    'ssp.',
+    'tracking',
+    'analytics',
+    'commercial',
+    'insert.',
+    'preroll',
+    'midroll',
+    'postroll',
+  ],
+  safeDomains: [
+    'hhuus.com',
+    'bvvvvvvvvv1f.com',
+    'play-cdn',
+    'modujx',
+    'ffzy',
+    'sdzy',
+    'wujin',
+    'heimuer',
+    'lzizy',
+    'alicdn.com',
+    'aliyuncs.com',
+    'aliyun',
+    'qcloud',
+    'myqcloud.com',
+    'ksyun',
+    'ks-cdn',
+    'huaweicloud',
+    'hwcdn',
+    'baidubce',
+    'bcebos.com',
+    'cdn.bcebos',
+    'cdn.jsdelivr',
+    'bootcdn',
+    'staticfile',
+    'unpkg',
+    'cdnjs',
+  ],
+};
+
+interface ParsedSegment {
+  duration: number;
+  discontinuityGroup: number;
+  infLine: string;
+  lineIndex: number;
+  url?: string;
+  urlLineIndex?: number;
+  isAdDomain?: boolean;
+}
+
+interface ParsedM3U8 {
+  lines: string[];
+  segments: ParsedSegment[];
+  discontinuityCount: number;
+  totalDuration: number;
+}
+
+export interface FilterResult {
+  filtered: string;
+  adsRemoved: number;
+  adsDuration: number;
+  changed: boolean;
+}
+
+function isAdDomain(url: string, config: AdFilterConfig): boolean {
+  if (!url) return false;
+  const lowerUrl = url.toLowerCase();
+  for (const safe of config.safeDomains) {
+    if (lowerUrl.includes(safe)) return false;
+  }
+  for (const pattern of config.adDomainPatterns) {
+    if (lowerUrl.includes(pattern)) return true;
+  }
+  return false;
+}
+
+function parseM3U8(content: string, config: AdFilterConfig): ParsedM3U8 {
+  const lines = content.split('\n').map((l) => l.trim());
+  const segments: ParsedSegment[] = [];
+  let currentSegment: ParsedSegment | null = null;
+  let discontinuityCount = 0;
+  let currentDiscontinuityGroup = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (line.startsWith('#EXT-X-DISCONTINUITY')) {
+      discontinuityCount++;
+      currentDiscontinuityGroup = discontinuityCount;
+      continue;
+    }
+
+    if (line.startsWith('#EXTINF:')) {
+      const match = line.match(/#EXTINF:([\d.]+)/);
+      const duration = match ? parseFloat(match[1]) : 0;
+      currentSegment = {
+        duration,
+        discontinuityGroup: currentDiscontinuityGroup,
+        infLine: line,
+        lineIndex: i,
+      };
+      continue;
+    }
+
+    if (currentSegment && line && !line.startsWith('#')) {
+      currentSegment.url = line;
+      currentSegment.urlLineIndex = i;
+      currentSegment.isAdDomain = isAdDomain(line, config);
+      segments.push(currentSegment);
+      currentSegment = null;
+    }
+  }
+
+  return {
+    lines,
+    segments,
+    discontinuityCount,
+    totalDuration: segments.reduce((sum, s) => sum + s.duration, 0),
+  };
+}
+
+function detectAdSegments(
+  segments: ParsedSegment[],
+  config: AdFilterConfig,
+): Set<number> {
+  const adSegmentIndices = new Set<number>();
+
+  segments.forEach((seg, idx) => {
+    if (seg.isAdDomain) adSegmentIndices.add(idx);
+  });
+
+  const groups: Record<number, (ParsedSegment & { index: number })[]> = {};
+  segments.forEach((seg, idx) => {
+    const g = seg.discontinuityGroup;
+    if (!groups[g]) groups[g] = [];
+    groups[g].push({ ...seg, index: idx });
+  });
+
+  const groupKeys = Object.keys(groups)
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  if (groupKeys.length <= 1) return adSegmentIndices;
+
+  const groupDurations: Record<number, number> = {};
+  let maxDuration = 0;
+  let mainContentGroup = 0;
+
+  for (const gKey of groupKeys) {
+    const duration = groups[gKey].reduce((sum, s) => sum + s.duration, 0);
+    groupDurations[gKey] = duration;
+    if (duration > maxDuration) {
+      maxDuration = duration;
+      mainContentGroup = gKey;
+    }
+  }
+
+  for (const gKey of groupKeys) {
+    if (gKey === mainContentGroup) continue;
+
+    const group = groups[gKey];
+    const groupDuration = groupDurations[gKey];
+
+    if (groupDuration > config.maxAdDuration) continue;
+
+    const isAdByDuration =
+      groupDuration >= config.minAdDuration &&
+      groupDuration <= config.maxAdDuration;
+    const isAdBySegmentCount = group.length <= config.maxConsecutiveAdSegments;
+
+    if (isAdByDuration && isAdBySegmentCount) {
+      group.forEach((seg) => adSegmentIndices.add(seg.index));
+    }
+  }
+
+  return adSegmentIndices;
+}
+
+/**
+ * 过滤 M3U8 文本，移除广告分段。
+ *
+ * 不修改主播放列表（包含 #EXT-X-STREAM-INF 的）；只处理变体播放列表。
+ * 仅删除 m3u8 中的广告段引用，TS 分片仍由播放器直连上游 CDN 拉取。
+ */
+export function filterM3U8(
+  content: string,
+  config: AdFilterConfig = DEFAULT_AD_FILTER_CONFIG,
+): FilterResult {
+  if (!config.enabled) {
+    return { filtered: content, adsRemoved: 0, adsDuration: 0, changed: false };
+  }
+
+  // 主播放列表不处理
+  if (content.includes('#EXT-X-STREAM-INF')) {
+    return { filtered: content, adsRemoved: 0, adsDuration: 0, changed: false };
+  }
+
+  const parsed = parseM3U8(content, config);
+
+  if (
+    parsed.discontinuityCount === 0 &&
+    !parsed.segments.some((s) => s.isAdDomain)
+  ) {
+    return { filtered: content, adsRemoved: 0, adsDuration: 0, changed: false };
+  }
+
+  const adIndices = detectAdSegments(parsed.segments, config);
+
+  if (adIndices.size === 0) {
+    return { filtered: content, adsRemoved: 0, adsDuration: 0, changed: false };
+  }
+
+  let adsDuration = 0;
+  adIndices.forEach((idx) => {
+    adsDuration += parsed.segments[idx].duration;
+  });
+
+  const linesToRemove = new Set<number>();
+  adIndices.forEach((idx) => {
+    const seg = parsed.segments[idx];
+    linesToRemove.add(seg.lineIndex);
+    if (seg.urlLineIndex !== undefined) linesToRemove.add(seg.urlLineIndex);
+  });
+
+  // 第一轮：移除广告 EXTINF/URL 行；删除完全位于广告段之前的 DISCONTINUITY
+  const filteredLines: string[] = [];
+  let hadContentBefore = false;
+  let removedAdGroup = false;
+
+  for (let i = 0; i < parsed.lines.length; i++) {
+    const line = parsed.lines[i];
+
+    if (line.startsWith('#EXT-X-DISCONTINUITY')) {
+      let allAds = true;
+      let hasSegments = false;
+
+      for (let j = i + 1; j < parsed.lines.length; j++) {
+        const nextLine = parsed.lines[j];
+        if (
+          nextLine.startsWith('#EXT-X-DISCONTINUITY') ||
+          nextLine.startsWith('#EXT-X-ENDLIST')
+        ) {
+          break;
+        }
+        if (nextLine && !nextLine.startsWith('#')) {
+          hasSegments = true;
+          const segIdx = parsed.segments.findIndex((s) => s.url === nextLine);
+          if (segIdx >= 0 && !adIndices.has(segIdx)) {
+            allAds = false;
+            break;
+          }
+        }
+      }
+
+      if (hasSegments && allAds) {
+        removedAdGroup = true;
+        continue;
+      }
+
+      if (removedAdGroup && hadContentBefore) {
+        filteredLines.push(line);
+        removedAdGroup = false;
+        continue;
+      }
+    }
+
+    if (!linesToRemove.has(i)) {
+      filteredLines.push(line);
+      if (line && !line.startsWith('#')) {
+        const segIdx = parsed.segments.findIndex((s) => s.url === line);
+        if (segIdx >= 0 && !adIndices.has(segIdx)) {
+          hadContentBefore = true;
+        }
+      }
+    }
+  }
+
+  // 第二轮：移除连续/末尾多余的 DISCONTINUITY
+  const cleanedLines: string[] = [];
+  for (let i = 0; i < filteredLines.length; i++) {
+    const line = filteredLines[i];
+    if (line.startsWith('#EXT-X-DISCONTINUITY')) {
+      let nextNonEmpty = '';
+      for (let j = i + 1; j < filteredLines.length; j++) {
+        if (filteredLines[j].trim()) {
+          nextNonEmpty = filteredLines[j];
+          break;
+        }
+      }
+      if (
+        nextNonEmpty.startsWith('#EXT-X-DISCONTINUITY') ||
+        nextNonEmpty.startsWith('#EXT-X-ENDLIST') ||
+        !nextNonEmpty
+      ) {
+        continue;
+      }
+    }
+    cleanedLines.push(line);
+  }
+
+  // 第三轮：移除首个分段前的 DISCONTINUITY
+  const finalLines: string[] = [];
+  let foundFirstSegment = false;
+  for (const line of cleanedLines) {
+    if (!foundFirstSegment && line.startsWith('#EXT-X-DISCONTINUITY')) {
+      continue;
+    }
+    if (line.startsWith('#EXTINF:')) {
+      foundFirstSegment = true;
+    }
+    finalLines.push(line);
+  }
+
+  // 第四轮：广告移除后，剩余的 DISCONTINUITY 已无意义，且
+  // 部分播放器在 DISCONTINUITY 处会出现音频采样率重置 bug，全部移除
+  const noDiscoLines = finalLines.filter(
+    (line) => !line.startsWith('#EXT-X-DISCONTINUITY'),
+  );
+
+  return {
+    filtered: noDiscoLines.join('\n'),
+    adsRemoved: adIndices.size,
+    adsDuration,
+    changed: true,
+  };
+}

--- a/src/lib/admin.types.ts
+++ b/src/lib/admin.types.ts
@@ -84,6 +84,7 @@ export interface AdminConfig {
     from: 'config' | 'custom';
     disabled?: boolean;
     is_adult?: boolean;
+    disable_ad_filter?: boolean;
   }[];
   CustomCategories: {
     name?: string;
@@ -129,6 +130,9 @@ export interface AdminConfig {
     ReverseProxy: string;
   };
   PrivateLibraryConfig?: PrivateLibraryConfig;
+  AdFilterConfig?: {
+    enabled: boolean;
+  };
 }
 
 export interface AdminConfigResult {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,6 +12,7 @@ export interface ApiSite {
   name: string;
   detail?: string;
   is_adult?: boolean; // 标记是否为成人资源
+  disable_ad_filter?: boolean; // 该源不走 m3u8 广告过滤代理
 }
 
 export interface LiveCfg {
@@ -660,6 +661,7 @@ export async function getAvailableApiSites(user?: string): Promise<ApiSite[]> {
         api: s.api,
         detail: s.detail,
         is_adult: s.is_adult,
+        disable_ad_filter: s.disable_ad_filter,
       }));
   }
 
@@ -686,6 +688,7 @@ export async function getAvailableApiSites(user?: string): Promise<ApiSite[]> {
           api: s.api,
           detail: s.detail,
           is_adult: s.is_adult,
+          disable_ad_filter: s.disable_ad_filter,
         }));
     }
   }

--- a/src/lib/episode-rewriter.ts
+++ b/src/lib/episode-rewriter.ts
@@ -1,0 +1,66 @@
+import { NextRequest } from 'next/server';
+
+import { SearchResult } from '@/lib/types';
+
+function isAdFilterEnabled(): boolean {
+  const flag = process.env.ENABLE_AD_FILTER;
+  if (flag === undefined) return true; // 默认开
+  return flag === 'true' || flag === '1';
+}
+
+function adFilterDisabledByQuery(request: NextRequest): boolean {
+  const v = request.nextUrl.searchParams.get('adfilter');
+  return v === 'false' || v === '0';
+}
+
+function buildFilterProxyUrl(request: NextRequest, upstreamUrl: string): string {
+  const host = request.headers.get('host');
+  const protocol =
+    request.headers.get('x-forwarded-proto') ||
+    request.nextUrl.protocol.replace(':', '') ||
+    'http';
+  return `${protocol}://${host}/api/proxy/m3u8-filter?url=${encodeURIComponent(
+    upstreamUrl,
+  )}`;
+}
+
+function shouldRewriteEpisode(url: string): boolean {
+  if (!url) return false;
+  if (!/^https?:\/\//i.test(url)) return false; // 跳过 /api/private-library/stream 这类内部路径
+  if (!/\.m3u8(\?|#|$)/i.test(url)) return false; // 只处理 m3u8
+  return true;
+}
+
+/**
+ * 把 SearchResult 的 episodes 数组里的 m3u8 URL 包成
+ * /api/proxy/m3u8-filter?url=... 形式，过滤上游广告。
+ *
+ * 跳过条件：
+ * - 服务端 ENABLE_AD_FILTER=false
+ * - 客户端请求带 ?adfilter=false 显式禁用
+ * - source 是 private_library（私人影库已是内部代理 URL）
+ * - URL 不是 http/https 或不是 m3u8
+ */
+export function rewriteEpisodesForAdFilter<T extends SearchResult | null | undefined>(
+  result: T,
+  request: NextRequest,
+): T {
+  if (!result) return result;
+  if (!isAdFilterEnabled() || adFilterDisabledByQuery(request)) return result;
+  if (result.source === 'private_library') return result;
+  if (!Array.isArray(result.episodes) || result.episodes.length === 0) return result;
+
+  const rewritten = result.episodes.map((ep) =>
+    shouldRewriteEpisode(ep) ? buildFilterProxyUrl(request, ep) : ep,
+  );
+
+  return { ...result, episodes: rewritten };
+}
+
+export function rewriteEpisodesForAdFilterMany(
+  results: SearchResult[],
+  request: NextRequest,
+): SearchResult[] {
+  if (!isAdFilterEnabled() || adFilterDisabledByQuery(request)) return results;
+  return results.map((r) => rewriteEpisodesForAdFilter(r, request));
+}

--- a/src/lib/episode-rewriter.ts
+++ b/src/lib/episode-rewriter.ts
@@ -1,11 +1,19 @@
 import { NextRequest } from 'next/server';
 
+import { AdminConfig } from '@/lib/admin.types';
+import { getConfig } from '@/lib/config';
 import { SearchResult } from '@/lib/types';
 
-function isAdFilterEnabled(): boolean {
-  const flag = process.env.ENABLE_AD_FILTER;
-  if (flag === undefined) return true; // 默认开
-  return flag === 'true' || flag === '1';
+/**
+ * 解析广告过滤是否启用：admin 后台开关 > 环境变量 > 默认开。
+ * admin 后台未配置时回落到 ENABLE_AD_FILTER；都没配置时默认 true。
+ */
+function isAdFilterEnabled(adminConfig: AdminConfig | null): boolean {
+  const adminFlag = adminConfig?.AdFilterConfig?.enabled;
+  if (typeof adminFlag === 'boolean') return adminFlag;
+  const envFlag = process.env.ENABLE_AD_FILTER;
+  if (envFlag === undefined) return true;
+  return envFlag === 'true' || envFlag === '1';
 }
 
 function adFilterDisabledByQuery(request: NextRequest): boolean {
@@ -31,24 +39,37 @@ function shouldRewriteEpisode(url: string): boolean {
   return true;
 }
 
+function isSourceDisabled(
+  adminConfig: AdminConfig | null,
+  sourceKey: string | undefined,
+): boolean {
+  if (!adminConfig || !sourceKey) return false;
+  const entry = adminConfig.SourceConfig?.find((s) => s.key === sourceKey);
+  return !!entry?.disable_ad_filter;
+}
+
 /**
  * 把 SearchResult 的 episodes 数组里的 m3u8 URL 包成
  * /api/proxy/m3u8-filter?url=... 形式，过滤上游广告。
  *
  * 跳过条件：
- * - 服务端 ENABLE_AD_FILTER=false
+ * - admin 后台关掉了广告过滤（或环境变量 ENABLE_AD_FILTER=false）
  * - 客户端请求带 ?adfilter=false 显式禁用
+ * - 该源在后台被标记为 disable_ad_filter
  * - source 是 private_library（私人影库已是内部代理 URL）
  * - URL 不是 http/https 或不是 m3u8
  */
-export function rewriteEpisodesForAdFilter<T extends SearchResult | null | undefined>(
-  result: T,
-  request: NextRequest,
-): T {
+export async function rewriteEpisodesForAdFilter<
+  T extends SearchResult | null | undefined,
+>(result: T, request: NextRequest): Promise<T> {
   if (!result) return result;
-  if (!isAdFilterEnabled() || adFilterDisabledByQuery(request)) return result;
+  const adminConfig = await safeGetConfig();
+  if (!isAdFilterEnabled(adminConfig) || adFilterDisabledByQuery(request))
+    return result;
   if (result.source === 'private_library') return result;
-  if (!Array.isArray(result.episodes) || result.episodes.length === 0) return result;
+  if (isSourceDisabled(adminConfig, result.source)) return result;
+  if (!Array.isArray(result.episodes) || result.episodes.length === 0)
+    return result;
 
   const rewritten = result.episodes.map((ep) =>
     shouldRewriteEpisode(ep) ? buildFilterProxyUrl(request, ep) : ep,
@@ -57,10 +78,30 @@ export function rewriteEpisodesForAdFilter<T extends SearchResult | null | undef
   return { ...result, episodes: rewritten };
 }
 
-export function rewriteEpisodesForAdFilterMany(
+export async function rewriteEpisodesForAdFilterMany(
   results: SearchResult[],
   request: NextRequest,
-): SearchResult[] {
-  if (!isAdFilterEnabled() || adFilterDisabledByQuery(request)) return results;
-  return results.map((r) => rewriteEpisodesForAdFilter(r, request));
+): Promise<SearchResult[]> {
+  const adminConfig = await safeGetConfig();
+  if (!isAdFilterEnabled(adminConfig) || adFilterDisabledByQuery(request))
+    return results;
+
+  // 对每条结果按"源是否豁免"独立判断
+  return results.map((r) => {
+    if (isSourceDisabled(adminConfig, r.source)) return r;
+    if (r.source === 'private_library') return r;
+    if (!Array.isArray(r.episodes) || r.episodes.length === 0) return r;
+    const rewritten = r.episodes.map((ep) =>
+      shouldRewriteEpisode(ep) ? buildFilterProxyUrl(request, ep) : ep,
+    );
+    return { ...r, episodes: rewritten };
+  });
+}
+
+async function safeGetConfig(): Promise<AdminConfig | null> {
+  try {
+    return await getConfig();
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
Adds an opt-out HLS ad filter that strips DISCONTINUITY-bracketed ad segments from variant playlists before they reach the player.

- src/lib/ad-filter.ts: TS port of the dongguatv ad-filter algorithm (groups segments by EXT-X-DISCONTINUITY, identifies the longest group as main content, removes other short groups within ad duration thresholds; also blacklists known ad CDN domains).
- src/app/api/proxy/m3u8-filter/route.ts: new endpoint that fetches upstream m3u8, resolves relative URLs to absolute (so TS still goes direct to upstream CDN), runs the filter, returns clean m3u8. Master playlists have variants rewritten through the same route.
- src/app/api/detail/route.ts: episodes URLs are wrapped through the filter route when ENABLE_AD_FILTER=true (default). Skips private_library and non-m3u8 URLs. Clients can pass ?adfilter=false to bypass.
- .env.example: document ENABLE_AD_FILTER.
- .github/workflows/docker-image.yml: downgrade missing dandanplay credentials from build failure to warning.

Only m3u8 text passes through the proxy; TS segments reference absolute upstream URLs, keeping server bandwidth negligible.