### PR TITLE
Fix/douban image proxy

### DIFF
--- a/src/components/ExternalImage.tsx
+++ b/src/components/ExternalImage.tsx
@@ -9,7 +9,11 @@ import {
   useState,
 } from 'react';
 
-import { POSTER_FALLBACK_SRC, resolveImageUrl } from '@/lib/image-url';
+import {
+  type DoubanImageProxyOverride,
+  POSTER_FALLBACK_SRC,
+  resolveImageUrl,
+} from '@/lib/image-url';
 
 type ExternalImageProps = Omit<ImageProps, 'src'> & {
   src: ImageProps['src'];
@@ -20,11 +24,29 @@ type ExternalImageProps = Omit<ImageProps, 'src'> & {
 function resolveSrc(
   src: ImageProps['src'],
   proxyWidth: number,
+  doubanImageProxy?: DoubanImageProxyOverride,
 ): ImageProps['src'] {
   if (typeof src !== 'string') {
     return src;
   }
-  return resolveImageUrl(src, { wsrvWidth: proxyWidth });
+  return resolveImageUrl(src, { wsrvWidth: proxyWidth, doubanImageProxy });
+}
+
+function readClientDoubanImageProxy(): DoubanImageProxyOverride | undefined {
+  if (typeof window === 'undefined') return undefined;
+  const runtime = window.RUNTIME_CONFIG ?? {};
+  let storedType: string | null = null;
+  let storedUrl: string | null = null;
+  try {
+    storedType = window.localStorage.getItem('doubanImageProxyType');
+    storedUrl = window.localStorage.getItem('doubanImageProxyUrl');
+  } catch {
+    // localStorage 被禁用时静默回退
+  }
+  return {
+    proxyType: storedType ?? runtime.DOUBAN_IMAGE_PROXY_TYPE ?? undefined,
+    proxyUrl: storedUrl ?? runtime.DOUBAN_IMAGE_PROXY ?? undefined,
+  };
 }
 
 export default function ExternalImage(props: ExternalImageProps) {
@@ -38,17 +60,20 @@ export default function ExternalImage(props: ExternalImageProps) {
     ...rest
   } = props;
 
-  const resolvedSrc = useMemo(
+  // SSR 与首屏渲染只走 process.env 默认值，确保两端 HTML 一致避免 hydration 警告。
+  const ssrSafeSrc = useMemo(
     () => resolveSrc(src, proxyWidth),
     [src, proxyWidth],
   );
-  const [currentSrc, setCurrentSrc] = useState<ImageProps['src']>(resolvedSrc);
+  const [currentSrc, setCurrentSrc] = useState<ImageProps['src']>(ssrSafeSrc);
   const [fallbackApplied, setFallbackApplied] = useState(false);
 
+  // 客户端挂载后再叠加 RUNTIME_CONFIG / localStorage 中的用户/管理员选择。
   useEffect(() => {
-    setCurrentSrc(resolvedSrc);
+    const override = readClientDoubanImageProxy();
+    setCurrentSrc(resolveSrc(src, proxyWidth, override));
     setFallbackApplied(false);
-  }, [resolvedSrc]);
+  }, [src, proxyWidth]);
 
   const handleError = useCallback(
     (e: SyntheticEvent<HTMLImageElement, Event>) => {

--- a/src/lib/image-url.ts
+++ b/src/lib/image-url.ts
@@ -1,16 +1,35 @@
 export const POSTER_FALLBACK_SRC = '/poster-fallback.svg';
 
 const DEFAULT_WSRV_WIDTH = 256;
-const DOUBAN_DIRECT_HOST = 'img.doubanio.cmliussss.net';
-const TIER1_DIRECT_HOSTS = new Set([
-  'img.doubanio.cmliussss.net',
-  'img.doubanio.cmliussss.com',
-  'lain.bgm.tv',
-]);
+const DEFAULT_DOUBAN_IMAGE_PROXY_TYPE = 'cmliussss-cdn-tencent';
+const TIER1_DIRECT_HOSTS = new Set(['lain.bgm.tv']);
 const WSRV_HOSTS = new Set(['wsrv.nl', 'images.weserv.nl']);
+const CMLIUSSSS_TENCENT_HOST = 'img.doubanio.cmliussss.net';
+const CMLIUSSSS_ALI_HOST = 'img.doubanio.cmliussss.com';
+const DOUBAN_DIRECT_HOST = 'img.doubanio.com';
+const DOUBAN_IMG3_HOST = 'img3.doubanio.com';
+
+export type DoubanImageProxyType =
+  | 'direct'
+  | 'server'
+  | 'img3'
+  | 'cmliussss-cdn-tencent'
+  | 'cmliussss-cdn-ali'
+  | 'custom';
+
+export interface DoubanImageProxyOverride {
+  proxyType?: string;
+  proxyUrl?: string;
+}
 
 export interface ResolveImageUrlOptions {
   wsrvWidth?: number;
+  /**
+   * 显式覆盖豆瓣图片代理。SSR 与首次客户端渲染保持一致以避免 hydration 不匹配，
+   * 因此调用方应只在 client 端的 effect 中读取 localStorage / RUNTIME_CONFIG
+   * 后再传入；不传时回退到 NEXT_PUBLIC_DOUBAN_IMAGE_PROXY_* 环境变量默认值。
+   */
+  doubanImageProxy?: DoubanImageProxyOverride;
 }
 
 function normalizeWsrvWidth(width?: number): number {
@@ -44,12 +63,74 @@ function isDoubanHost(hostname: string): boolean {
 }
 
 function isDoubanImageHost(hostname: string): boolean {
-  return hostname === 'doubanio.com' || hostname.endsWith('.doubanio.com');
+  return (
+    hostname === 'doubanio.com' ||
+    hostname.endsWith('.doubanio.com') ||
+    hostname === CMLIUSSSS_TENCENT_HOST ||
+    hostname === CMLIUSSSS_ALI_HOST
+  );
+}
+
+function isCmliussssHost(hostname: string): boolean {
+  return hostname === CMLIUSSSS_TENCENT_HOST || hostname === CMLIUSSSS_ALI_HOST;
 }
 
 function toWsrvUrl(absoluteUrl: string, wsrvWidth: number): string {
   const sanitizedTarget = absoluteUrl.replace(/^https?:\/\//i, '');
   return `https://wsrv.nl/?url=${encodeURIComponent(sanitizedTarget)}&w=${wsrvWidth}&default=blank`;
+}
+
+function getDefaultDoubanImageProxy(): {
+  proxyType: string;
+  proxyUrl: string;
+} {
+  return {
+    proxyType:
+      process.env.NEXT_PUBLIC_DOUBAN_IMAGE_PROXY_TYPE ||
+      DEFAULT_DOUBAN_IMAGE_PROXY_TYPE,
+    proxyUrl: process.env.NEXT_PUBLIC_DOUBAN_IMAGE_PROXY || '',
+  };
+}
+
+function applyDoubanImageProxy(
+  parsedUrl: URL,
+  proxyType: string,
+  proxyUrl: string,
+): string {
+  parsedUrl.protocol = 'https:';
+
+  switch (proxyType as DoubanImageProxyType) {
+    case 'direct':
+      return parsedUrl.toString();
+
+    case 'img3':
+      parsedUrl.hostname = DOUBAN_IMG3_HOST;
+      return parsedUrl.toString();
+
+    case 'cmliussss-cdn-tencent':
+      parsedUrl.hostname = CMLIUSSSS_TENCENT_HOST;
+      return parsedUrl.toString();
+
+    case 'cmliussss-cdn-ali':
+      parsedUrl.hostname = CMLIUSSSS_ALI_HOST;
+      return parsedUrl.toString();
+
+    case 'server':
+      return `/api/image-proxy?url=${encodeURIComponent(parsedUrl.toString())}`;
+
+    case 'custom': {
+      const trimmed = proxyUrl?.trim() ?? '';
+      if (!trimmed) {
+        // 没填自定义 URL 就当 direct，避免拼出无效请求
+        return parsedUrl.toString();
+      }
+      return `${trimmed}${encodeURIComponent(parsedUrl.toString())}`;
+    }
+
+    default:
+      parsedUrl.hostname = CMLIUSSSS_TENCENT_HOST;
+      return parsedUrl.toString();
+  }
 }
 
 export function resolveImageUrl(
@@ -88,9 +169,17 @@ export function resolveImageUrl(
   }
 
   if (isDoubanImageHost(hostname)) {
-    parsedUrl.protocol = 'https:';
-    parsedUrl.hostname = DOUBAN_DIRECT_HOST;
-    return parsedUrl.toString();
+    // 已经是 cmliussss 镜像的 URL（来自旧缓存）先归一回 doubanio.com，
+    // 让下面的代理分支按用户选择重新派发；选 direct 时也能真正回到豆瓣官源。
+    if (isCmliussssHost(hostname)) {
+      parsedUrl.hostname = DOUBAN_DIRECT_HOST;
+    }
+    const defaults = getDefaultDoubanImageProxy();
+    const proxyType =
+      options.doubanImageProxy?.proxyType?.trim() || defaults.proxyType;
+    const proxyUrl =
+      options.doubanImageProxy?.proxyUrl ?? defaults.proxyUrl ?? '';
+    return applyDoubanImageProxy(parsedUrl, proxyType, proxyUrl);
   }
 
   if (isDoubanHost(hostname)) {

--- a/src/lib/image-url.ts
+++ b/src/lib/image-url.ts
@@ -119,7 +119,13 @@ function applyDoubanImageProxy(
         // 没填自定义 URL 就当 direct，避免拼出无效请求
         return parsedUrl.toString();
       }
-      return `${trimmed}${encodeURIComponent(parsedUrl.toString())}`;
+      const target = parsedUrl.toString();
+      // 与 douban.client.ts 的数据代理保持一致：cors-anywhere 走 raw 拼接，
+      // 其他自定义代理统一前缀 + 编码后的 URL（匹配 UI placeholder 的语义）。
+      if (trimmed === 'https://cors-anywhere.com/') {
+        return `${trimmed}${target}`;
+      }
+      return `${trimmed}${encodeURIComponent(target)}`;
     }
 
     default:

--- a/src/lib/image-url.ts
+++ b/src/lib/image-url.ts
@@ -6,7 +6,6 @@ const TIER1_DIRECT_HOSTS = new Set(['lain.bgm.tv']);
 const WSRV_HOSTS = new Set(['wsrv.nl', 'images.weserv.nl']);
 const CMLIUSSSS_TENCENT_HOST = 'img.doubanio.cmliussss.net';
 const CMLIUSSSS_ALI_HOST = 'img.doubanio.cmliussss.com';
-const DOUBAN_DIRECT_HOST = 'img.doubanio.com';
 const DOUBAN_IMG3_HOST = 'img3.doubanio.com';
 
 export type DoubanImageProxyType =
@@ -69,10 +68,6 @@ function isDoubanImageHost(hostname: string): boolean {
     hostname === CMLIUSSSS_TENCENT_HOST ||
     hostname === CMLIUSSSS_ALI_HOST
   );
-}
-
-function isCmliussssHost(hostname: string): boolean {
-  return hostname === CMLIUSSSS_TENCENT_HOST || hostname === CMLIUSSSS_ALI_HOST;
 }
 
 function toWsrvUrl(absoluteUrl: string, wsrvWidth: number): string {
@@ -169,11 +164,6 @@ export function resolveImageUrl(
   }
 
   if (isDoubanImageHost(hostname)) {
-    // 已经是 cmliussss 镜像的 URL（来自旧缓存）先归一回 doubanio.com，
-    // 让下面的代理分支按用户选择重新派发；选 direct 时也能真正回到豆瓣官源。
-    if (isCmliussssHost(hostname)) {
-      parsedUrl.hostname = DOUBAN_DIRECT_HOST;
-    }
     const defaults = getDefaultDoubanImageProxy();
     const proxyType =
       options.doubanImageProxy?.proxyType?.trim() || defaults.proxyType;


### PR DESCRIPTION
修复了站长管理/本地配置切换豆瓣图片代理不生效的问题，现在 CDN By CMLiussss（腾讯云）的证书异常导致图片代理失败。
添加修复代码后切换至CDN By CMLiussss（阿里云）就可以正常显示了。
<img width="2492" height="1344" alt="d0a866bd-a124-4d8d-a4a4-c7f9d31b76b2" src="https://github.com/user-attachments/assets/0ebc3556-6be7-4610-bed2-704a3918bf00" />
