### PR TITLE
feat: store user passwords as scrypt hashes with transparent migration

### DIFF
--- a/__tests__/password.test.js
+++ b/__tests__/password.test.js
@@ -1,0 +1,30 @@
+/* global describe, expect, it */
+
+const {
+  hashPassword,
+  isStoredPasswordHash,
+  normalizePasswordForStorage,
+  verifyStoredPassword,
+} = require('../src/lib/password');
+
+describe('password storage format', () => {
+  it('recognizes only the current scrypt storage format as a stored hash', async () => {
+    const hashed = await hashPassword('correct horse battery staple');
+
+    expect(isStoredPasswordHash(hashed)).toBe(true);
+    expect(isStoredPasswordHash('scrypt$1$1$1$salt$value')).toBe(false);
+    expect(isStoredPasswordHash('scrypt$16384$8$1$salt$value')).toBe(false);
+  });
+
+  it('hashes hash-like raw passwords that do not match the strict stored format', async () => {
+    const rawPassword = 'scrypt$1$1$1$salt$value';
+    const stored = await normalizePasswordForStorage(rawPassword);
+
+    expect(stored).not.toBe(rawPassword);
+    expect(isStoredPasswordHash(stored)).toBe(true);
+
+    await expect(
+      verifyStoredPassword(stored, rawPassword),
+    ).resolves.toMatchObject({ valid: true, needsRehash: false });
+  });
+});

--- a/src/lib/memory.db.ts
+++ b/src/lib/memory.db.ts
@@ -9,6 +9,7 @@
  */
 
 import { AdminConfig } from './admin.types';
+import { normalizePasswordForStorage, verifyStoredPassword } from './password';
 import {
   Favorite,
   IStorage,
@@ -113,13 +114,17 @@ export class MemoryStorage implements IStorage {
     if (this.users.has(userName)) {
       throw new Error('用户已存在');
     }
-    this.users.set(userName, password);
+    this.users.set(userName, await normalizePasswordForStorage(password));
   }
 
   async verifyUser(userName: string, password: string): Promise<boolean> {
     const storedPassword = this.users.get(userName);
     if (!storedPassword) return false;
-    return storedPassword === password;
+    const result = await verifyStoredPassword(storedPassword, password);
+    if (result.valid && result.needsRehash) {
+      this.users.set(userName, await normalizePasswordForStorage(password));
+    }
+    return result.valid;
   }
 
   async checkUserExist(userName: string): Promise<boolean> {
@@ -130,7 +135,7 @@ export class MemoryStorage implements IStorage {
     if (!this.users.has(userName)) {
       throw new Error('用户不存在');
     }
-    this.users.set(userName, newPassword);
+    this.users.set(userName, await normalizePasswordForStorage(newPassword));
   }
 
   async deleteUser(userName: string): Promise<void> {

--- a/src/lib/password.ts
+++ b/src/lib/password.ts
@@ -1,0 +1,98 @@
+import {
+  randomBytes,
+  scrypt as scryptCallback,
+  type ScryptOptions,
+  timingSafeEqual,
+} from 'crypto';
+
+const HASH_PREFIX = 'scrypt';
+const KEY_LENGTH = 64;
+const SCRYPT_N = 16384;
+const SCRYPT_R = 8;
+const SCRYPT_P = 1;
+const STORED_PASSWORD_HASH_PATTERN =
+  /^scrypt\$16384\$8\$1\$[A-Za-z0-9_-]{16,}\$[A-Za-z0-9_-]{80,}$/;
+
+function scrypt(
+  password: string,
+  salt: string,
+  keyLength: number,
+  options: ScryptOptions,
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    scryptCallback(password, salt, keyLength, options, (error, derivedKey) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(derivedKey as Buffer);
+    });
+  });
+}
+
+export function isStoredPasswordHash(
+  value: string | null | undefined,
+): boolean {
+  return Boolean(value && STORED_PASSWORD_HASH_PATTERN.test(value));
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = randomBytes(16).toString('base64url');
+  const derived = (await scrypt(password, salt, KEY_LENGTH, {
+    N: SCRYPT_N,
+    r: SCRYPT_R,
+    p: SCRYPT_P,
+    maxmem: 64 * 1024 * 1024,
+  })) as Buffer;
+
+  return [
+    HASH_PREFIX,
+    SCRYPT_N,
+    SCRYPT_R,
+    SCRYPT_P,
+    salt,
+    derived.toString('base64url'),
+  ].join('$');
+}
+
+export async function normalizePasswordForStorage(
+  password: string,
+): Promise<string> {
+  return isStoredPasswordHash(password) ? password : hashPassword(password);
+}
+
+export async function verifyStoredPassword(
+  storedPassword: string,
+  candidatePassword: string,
+): Promise<{ valid: boolean; needsRehash: boolean }> {
+  if (!isStoredPasswordHash(storedPassword)) {
+    return {
+      valid: storedPassword === candidatePassword,
+      needsRehash: storedPassword === candidatePassword,
+    };
+  }
+
+  const parts = storedPassword.split('$');
+  const n = Number(parts[1]);
+  const r = Number(parts[2]);
+  const p = Number(parts[3]);
+  const salt = parts[4];
+  const expected = Buffer.from(parts[5], 'base64url');
+
+  try {
+    const actual = (await scrypt(candidatePassword, salt, expected.length, {
+      N: n,
+      r,
+      p,
+      maxmem: 64 * 1024 * 1024,
+    })) as Buffer;
+
+    return {
+      valid:
+        expected.length === actual.length && timingSafeEqual(expected, actual),
+      needsRehash: n !== SCRYPT_N || r !== SCRYPT_R || p !== SCRYPT_P,
+    };
+  } catch {
+    return { valid: false, needsRehash: false };
+  }
+}

--- a/src/lib/redis-base.db.ts
+++ b/src/lib/redis-base.db.ts
@@ -3,6 +3,7 @@
 import { createClient, RedisClientType } from 'redis';
 
 import { AdminConfig } from './admin.types';
+import { normalizePasswordForStorage, verifyStoredPassword } from './password';
 import {
   Favorite,
   IStorage,
@@ -271,9 +272,9 @@ export abstract class BaseRedisStorage implements IStorage {
   }
 
   async registerUser(userName: string, password: string): Promise<void> {
-    // 简单存储明文密码，生产环境应加密
+    const passwordForStorage = await normalizePasswordForStorage(password);
     await this.withRetry(() =>
-      this.client.set(this.userPwdKey(userName), password),
+      this.client.set(this.userPwdKey(userName), passwordForStorage),
     );
   }
 
@@ -282,8 +283,14 @@ export abstract class BaseRedisStorage implements IStorage {
       this.client.get(this.userPwdKey(userName)),
     );
     if (stored === null) return false;
-    // 确保比较时都是字符串类型
-    return ensureString(stored) === password;
+    const result = await verifyStoredPassword(ensureString(stored), password);
+    if (result.valid && result.needsRehash) {
+      const passwordForStorage = await normalizePasswordForStorage(password);
+      await this.withRetry(() =>
+        this.client.set(this.userPwdKey(userName), passwordForStorage),
+      );
+    }
+    return result.valid;
   }
 
   // 检查用户是否存在
@@ -297,9 +304,9 @@ export abstract class BaseRedisStorage implements IStorage {
 
   // 修改用户密码
   async changePassword(userName: string, newPassword: string): Promise<void> {
-    // 简单存储明文密码，生产环境应加密
+    const passwordForStorage = await normalizePasswordForStorage(newPassword);
     await this.withRetry(() =>
-      this.client.set(this.userPwdKey(userName), newPassword),
+      this.client.set(this.userPwdKey(userName), passwordForStorage),
     );
   }
 

--- a/src/lib/upstash.db.ts
+++ b/src/lib/upstash.db.ts
@@ -3,6 +3,7 @@
 import { Redis } from '@upstash/redis';
 
 import { AdminConfig } from './admin.types';
+import { normalizePasswordForStorage, verifyStoredPassword } from './password';
 import {
   Favorite,
   IStorage,
@@ -160,8 +161,10 @@ export class UpstashRedisStorage implements IStorage {
   }
 
   async registerUser(userName: string, password: string): Promise<void> {
-    // 简单存储明文密码，生产环境应加密
-    await withRetry(() => this.client.set(this.userPwdKey(userName), password));
+    const passwordForStorage = await normalizePasswordForStorage(password);
+    await withRetry(() =>
+      this.client.set(this.userPwdKey(userName), passwordForStorage),
+    );
   }
 
   async verifyUser(userName: string, password: string): Promise<boolean> {
@@ -169,8 +172,14 @@ export class UpstashRedisStorage implements IStorage {
       this.client.get(this.userPwdKey(userName)),
     );
     if (stored === null) return false;
-    // 确保比较时都是字符串类型
-    return ensureString(stored) === password;
+    const result = await verifyStoredPassword(ensureString(stored), password);
+    if (result.valid && result.needsRehash) {
+      const passwordForStorage = await normalizePasswordForStorage(password);
+      await withRetry(() =>
+        this.client.set(this.userPwdKey(userName), passwordForStorage),
+      );
+    }
+    return result.valid;
   }
 
   // 检查用户是否存在
@@ -184,9 +193,9 @@ export class UpstashRedisStorage implements IStorage {
 
   // 修改用户密码
   async changePassword(userName: string, newPassword: string): Promise<void> {
-    // 简单存储明文密码，生产环境应加密
+    const passwordForStorage = await normalizePasswordForStorage(newPassword);
     await withRetry(() =>
-      this.client.set(this.userPwdKey(userName), newPassword),
+      this.client.set(this.userPwdKey(userName), passwordForStorage),
     );
   }
 


### PR DESCRIPTION
## 背景

重做系列第 2 个 PR（第 1 个是 #216），只包含密码存储加固，不含 auth cookie / middleware / 播放等其他改动。基于当前最新 `main`。

## 改动

- 新增 `src/lib/password.ts`：scrypt 哈希（N=16384, r=8, p=1）、常数时间比较验证、严格的存储哈希格式检测（防止「长得像哈希的明文密码」被误判为已导入哈希）。
- redis/kvrocks、upstash、memory 三个存储实现：注册和改密时写入哈希；已有明文密码的用户在下一次登录成功时透明地重写为哈希。
- 新增密码存储格式单元测试。

## ⚠️ 重要：这是单向迁移，回退有代价

明文密码在用户登录成功后会被就地改写成 `scrypt$...` 哈希。**如果之后把部署回退到还在做明文比对的旧版本，这些已迁移用户会因为存储值不再等于明文而无法登录**（表现为正确密码提示密码错误），需要重置密码或重新升级才能恢复。

这很可能就是上次 #214 合并→回退过程中「回退后登录问题仍然存在」的原因之一：在 #214 部署窗口内登录过的普通用户，其 `u:<用户名>:pwd` 已被改写为 `scrypt$` 开头的哈希，回退后旧代码无法验证。**如果当前生产库中存在 `scrypt$` 开头的 `u:*:pwd`，这些账号现在仍然无法登录**，可以用重置密码恢复，或合并本 PR 后自动恢复（本 PR 的验证逻辑同时接受明文和哈希）。

部署建议：合并本 PR 后如需再次回退，回退目标版本必须仍包含 `verifyStoredPassword` 兼容逻辑，或者先重置受影响用户密码。

## 验证（真实 Docker 部署）

- `docker build` 本分支镜像 — 成功。
- `docker run` + kvrocks 实测登录链路：
  - 站长正确密码 → `200`；错误密码 → `401`
  - 预置明文密码的普通用户首次登录 → `200`，存储值确认被改写为 `scrypt$16384$8$1$...`
  - 同一用户第二次登录（此时走哈希验证） → `200`
  - 错误密码 → `401`
- `jest`（password 测试套件）通过；`pnpm typecheck` 通过。

## 与后续 PR 的关系

本 PR 不改 cookie / 鉴权 / middleware。auth cookie 签名与登录限速在下一个 PR 单独提交。