### PR TITLE
feat: add SSRF guardrails for proxy, download, live and douban endpoints

### DIFF
--- a/__tests__/proxy-security.test.js
+++ b/__tests__/proxy-security.test.js
@@ -1,0 +1,119 @@
+/* global afterEach, beforeEach, describe, expect, it, jest */
+
+jest.mock('node:dns/promises', () => ({
+  lookup: jest.fn(),
+}));
+
+const { lookup } = require('node:dns/promises');
+const {
+  fetchWithValidatedRedirects,
+  validateProxyTargetUrl,
+} = require('../src/lib/proxy-security');
+
+const originalFetch = global.fetch;
+
+function clearProxyEnv() {
+  delete process.env.PROXY_ALLOW_PRIVATE_HOSTS;
+  delete process.env.PROXY_PRIVATE_HOST_ALLOWLIST;
+}
+
+function redirectResponse(location) {
+  return {
+    status: 302,
+    headers: new Headers({ location }),
+  };
+}
+
+function okResponse() {
+  return {
+    status: 200,
+    headers: new Headers(),
+  };
+}
+
+beforeEach(() => {
+  clearProxyEnv();
+  lookup.mockReset();
+  lookup.mockImplementation((hostname) => {
+    if (hostname === 'public.example') {
+      return Promise.resolve([{ address: '93.184.216.34', family: 4 }]);
+    }
+    if (hostname === 'nas.local') {
+      return Promise.resolve([{ address: '192.168.1.10', family: 4 }]);
+    }
+    return Promise.resolve([{ address: '93.184.216.34', family: 4 }]);
+  });
+});
+
+afterEach(() => {
+  clearProxyEnv();
+  jest.restoreAllMocks();
+  if (originalFetch === undefined) {
+    delete global.fetch;
+  } else {
+    global.fetch = originalFetch;
+  }
+});
+
+describe('proxy target validation', () => {
+  it('blocks private literal IPs by default', async () => {
+    await expect(
+      validateProxyTargetUrl('http://192.168.1.10/video.m3u8'),
+    ).rejects.toThrow('Blocked IP address');
+  });
+
+  it('allows explicitly allowlisted private literal IPs', async () => {
+    process.env.PROXY_ALLOW_PRIVATE_HOSTS = 'true';
+    process.env.PROXY_PRIVATE_HOST_ALLOWLIST = '192.168.1.10';
+
+    await expect(
+      validateProxyTargetUrl('http://192.168.1.10/video.m3u8'),
+    ).resolves.toBe('http://192.168.1.10/video.m3u8');
+  });
+
+  it('blocks hostnames that resolve to private IPs by default', async () => {
+    await expect(
+      validateProxyTargetUrl('http://nas.local/video.m3u8'),
+    ).rejects.toThrow('blocked IP address');
+  });
+
+  it('allows private resolved IPs only when the address is allowlisted', async () => {
+    process.env.PROXY_ALLOW_PRIVATE_HOSTS = 'on';
+    process.env.PROXY_PRIVATE_HOST_ALLOWLIST = '192.168.1.0/24';
+
+    await expect(
+      validateProxyTargetUrl('http://nas.local/video.m3u8'),
+    ).resolves.toBe('http://nas.local/video.m3u8');
+  });
+
+  it('resolves allowlisted hostnames before allowing private targets', async () => {
+    process.env.PROXY_ALLOW_PRIVATE_HOSTS = 'true';
+    process.env.PROXY_PRIVATE_HOST_ALLOWLIST = 'nas.local';
+
+    await expect(
+      validateProxyTargetUrl('http://nas.local/video.m3u8'),
+    ).resolves.toBe('http://nas.local/video.m3u8');
+
+    expect(lookup).toHaveBeenCalledWith('nas.local', {
+      all: true,
+      verbatim: true,
+    });
+  });
+
+  it('revalidates redirects before following them', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('http://127.0.0.1/latest'))
+      .mockResolvedValueOnce(okResponse());
+
+    await expect(
+      fetchWithValidatedRedirects(
+        'https://public.example/playlist.m3u8',
+        { method: 'GET' },
+        { timeoutMs: 1000 },
+      ),
+    ).rejects.toThrow('Blocked IP address');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/douban/health/route.ts
+++ b/src/app/api/douban/health/route.ts
@@ -6,6 +6,7 @@ import {
   resolveServerDoubanProxyConfig,
 } from '@/lib/douban-proxy';
 import { resolveImageUrlCandidates } from '@/lib/image-url';
+import { fetchWithValidatedRedirects } from '@/lib/proxy-security';
 
 export const runtime = 'nodejs';
 
@@ -67,9 +68,9 @@ async function probeImageCandidates(request: Request): Promise<{
     const startedAt = Date.now();
 
     try {
-      const response = await fetch(absoluteUrl, {
+      const fetchInit = {
         signal: controller.signal,
-        cache: 'no-store',
+        cache: 'no-store' as const,
         headers: {
           Referer: 'https://movie.douban.com/',
           'User-Agent':
@@ -77,7 +78,12 @@ async function probeImageCandidates(request: Request): Promise<{
           Accept:
             'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
         },
-      });
+      };
+      const response = candidate.startsWith('/')
+        ? await fetch(absoluteUrl, fetchInit)
+        : await fetchWithValidatedRedirects(absoluteUrl, fetchInit, {
+            timeoutMs: 5000,
+          });
       const durationMs = Date.now() - startedAt;
       const contentType = response.headers.get('content-type') || '';
       await response.body?.cancel().catch(() => undefined);

--- a/src/app/api/download/ffmpeg/route.ts
+++ b/src/app/api/download/ffmpeg/route.ts
@@ -11,6 +11,7 @@ import {
   resumeFfmpegJob,
   startFfmpegDownload,
 } from '@/lib/ffmpeg-download';
+import { validateProxyTargetUrl } from '@/lib/proxy-security';
 
 export const runtime = 'nodejs';
 export const fetchCache = 'force-no-store';
@@ -171,6 +172,22 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Missing title' }, { status: 400 });
     }
 
+    const isSameOriginApiSource = shouldForwardSameOriginAuth(
+      request,
+      sourceUrl,
+    );
+    let safeSourceUrl = sourceUrl;
+    if (!isSameOriginApiSource) {
+      try {
+        safeSourceUrl = await validateProxyTargetUrl(sourceUrl);
+      } catch {
+        return NextResponse.json(
+          { error: 'Blocked or invalid sourceUrl' },
+          { status: 400 },
+        );
+      }
+    }
+
     const runtimeSupport = await getFfmpegRuntimeSupport();
     if (!runtimeSupport.supported) {
       return NextResponse.json(
@@ -188,14 +205,14 @@ export async function POST(request: NextRequest) {
     let job: FfmpegJobSnapshot;
     try {
       job = await startFfmpegDownload({
-        sourceUrl: buildDockerInternalSourceUrl(request, sourceUrl),
+        sourceUrl: buildDockerInternalSourceUrl(request, safeSourceUrl),
         title: payload.title.trim(),
         fileNameHint: payload.fileNameHint?.trim(),
         requestHeaders: {
           referer: normalizeHeaderValue(payload.referer),
           origin: normalizeHeaderValue(payload.origin),
           userAgent: normalizeHeaderValue(payload.ua),
-          cookie: shouldForwardSameOriginAuth(request, sourceUrl)
+          cookie: isSameOriginApiSource
             ? normalizeHeaderValue(request.headers.get('cookie') || undefined)
             : undefined,
         },

--- a/src/app/api/download/proxy/route.ts
+++ b/src/app/api/download/proxy/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { verifyApiAuth } from '@/lib/auth';
+import { fetchWithValidatedRedirects } from '@/lib/proxy-security';
 
 export const runtime = 'nodejs';
 export const fetchCache = 'force-no-store';
@@ -288,7 +289,10 @@ async function fetchUpstreamWithFallback(
   },
 ): Promise<{ response: Response | null; error: FetchAttemptError | null }> {
   let lastError: FetchAttemptError | null = null;
-  const fetchUrl = buildDockerInternalFetchUrl(request, targetUrl);
+  const isSameOriginApi = shouldForwardSameOriginAuth(request, targetUrl);
+  const fetchUrl = isSameOriginApi
+    ? buildDockerInternalFetchUrl(request, targetUrl)
+    : targetUrl;
 
   for (const variant of options.variants) {
     const headers = buildRequestHeaders(request, {
@@ -303,13 +307,23 @@ async function fetchUpstreamWithFallback(
       const timeoutId = setTimeout(() => controller.abort(), options.timeoutMs);
       let response: Response;
       try {
-        response = await fetch(fetchUrl, {
-          method: 'GET',
-          headers,
-          signal: controller.signal,
-          redirect: 'follow',
-          cache: 'no-store',
-        });
+        response = isSameOriginApi
+          ? await fetch(fetchUrl, {
+              method: 'GET',
+              headers,
+              signal: controller.signal,
+              redirect: 'follow',
+              cache: 'no-store',
+            })
+          : await fetchWithValidatedRedirects(
+              fetchUrl,
+              {
+                method: 'GET',
+                headers,
+                cache: 'no-store',
+              },
+              { timeoutMs: options.timeoutMs },
+            );
       } finally {
         clearTimeout(timeoutId);
       }

--- a/src/app/api/live/precheck/route.ts
+++ b/src/app/api/live/precheck/route.ts
@@ -3,6 +3,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getConfig } from '@/lib/config';
+import { fetchWithValidatedRedirects } from '@/lib/proxy-security';
 
 export const runtime = 'nodejs';
 
@@ -143,21 +144,27 @@ export async function GET(request: NextRequest) {
     );
     requestHeaders.set('Origin', `${targetUrl.protocol}//${targetUrl.host}`);
 
-    let response = await fetch(decodedUrl, {
-      cache: 'no-cache',
-      redirect: 'follow',
-      headers: {
-        ...Object.fromEntries(requestHeaders.entries()),
-        Range: 'bytes=0-2047',
+    let response = await fetchWithValidatedRedirects(
+      decodedUrl,
+      {
+        cache: 'no-cache',
+        headers: {
+          ...Object.fromEntries(requestHeaders.entries()),
+          Range: 'bytes=0-2047',
+        },
       },
-    });
+      { timeoutMs: 10000 },
+    );
 
     if (response.status === 416) {
-      response = await fetch(decodedUrl, {
-        cache: 'no-cache',
-        redirect: 'follow',
-        headers: requestHeaders,
-      });
+      response = await fetchWithValidatedRedirects(
+        decodedUrl,
+        {
+          cache: 'no-cache',
+          headers: requestHeaders,
+        },
+        { timeoutMs: 10000 },
+      );
     }
 
     if (!response.ok && response.status !== 206) {

--- a/src/app/api/proxy/cms/route.ts
+++ b/src/app/api/proxy/cms/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { resolveAdultFilter } from '@/lib/adult-filter';
 import { getConfig } from '@/lib/config';
+import { fetchWithValidatedRedirects } from '@/lib/proxy-security';
 
 export const runtime = 'nodejs';
 export const fetchCache = 'force-no-store';
@@ -211,65 +212,59 @@ export async function GET(request: NextRequest) {
       headers.Origin = origin;
     }
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 20_000);
-
-    try {
-      const response = await fetch(decodedUrl, {
+    const response = await fetchWithValidatedRedirects(
+      decodedUrl,
+      {
         method: 'GET',
         headers,
-        signal: controller.signal,
         cache: 'no-store',
+      },
+      { timeoutMs: 20_000 },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '');
+      console.error(
+        '[CMS Proxy] ❌ Upstream error:',
+        response.status,
+        errorText.substring(0, 200),
+      );
+      return NextResponse.json(
+        {
+          error: `Upstream server responded with ${response.status}`,
+          code: 'UPSTREAM_ERROR',
+          status: response.status,
+          target: decodedUrl,
+        },
+        {
+          status: 502,
+          headers: corsHeaders(),
+        },
+      );
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    const text = await response.text();
+    const elapsed = Date.now() - startTime;
+
+    try {
+      const cleanText = text.trim().replace(/^\uFEFF/, '');
+      const data = JSON.parse(cleanText);
+      return NextResponse.json(data, {
+        headers: {
+          ...corsHeaders(),
+          'X-Proxy-Time': `${elapsed}ms`,
+        },
       });
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        const errorText = await response.text().catch(() => '');
-        console.error(
-          '[CMS Proxy] ❌ Upstream error:',
-          response.status,
-          errorText.substring(0, 200),
-        );
-        return NextResponse.json(
-          {
-            error: `Upstream server responded with ${response.status}`,
-            code: 'UPSTREAM_ERROR',
-            status: response.status,
-            target: decodedUrl,
-          },
-          {
-            status: 502,
-            headers: corsHeaders(),
-          },
-        );
-      }
-
-      const contentType = response.headers.get('content-type') || '';
-      const text = await response.text();
-      const elapsed = Date.now() - startTime;
-
-      try {
-        const cleanText = text.trim().replace(/^\uFEFF/, '');
-        const data = JSON.parse(cleanText);
-        return NextResponse.json(data, {
-          headers: {
-            ...corsHeaders(),
-            'X-Proxy-Time': `${elapsed}ms`,
-          },
-        });
-      } catch {
-        return new NextResponse(text, {
-          status: 200,
-          headers: {
-            'Content-Type': contentType || 'text/plain; charset=utf-8',
-            ...corsHeaders(),
-            'X-Proxy-Time': `${elapsed}ms`,
-          },
-        });
-      }
-    } catch (fetchError) {
-      clearTimeout(timeoutId);
-      throw fetchError;
+    } catch {
+      return new NextResponse(text, {
+        status: 200,
+        headers: {
+          'Content-Type': contentType || 'text/plain; charset=utf-8',
+          ...corsHeaders(),
+          'X-Proxy-Time': `${elapsed}ms`,
+        },
+      });
     }
   } catch (error) {
     const elapsed = Date.now() - startTime;

--- a/src/app/api/proxy/key/route.ts
+++ b/src/app/api/proxy/key/route.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from 'next/server';
 
 import { getConfig } from '@/lib/config';
+import { fetchWithValidatedRedirects } from '@/lib/proxy-security';
 
 export const runtime = 'nodejs';
 
@@ -57,16 +58,19 @@ export async function GET(request: Request) {
 
   try {
     const targetUrl = new URL(decodedUrl);
-    const response = await fetch(decodedUrl, {
-      cache: 'no-cache',
-      redirect: 'follow',
-      headers: {
-        Accept: '*/*',
-        Origin: `${targetUrl.protocol}//${targetUrl.host}`,
-        Referer: `${targetUrl.protocol}//${targetUrl.host}${targetUrl.pathname}`,
-        'User-Agent': ua,
+    const response = await fetchWithValidatedRedirects(
+      decodedUrl,
+      {
+        cache: 'no-cache',
+        headers: {
+          Accept: '*/*',
+          Origin: `${targetUrl.protocol}//${targetUrl.host}`,
+          Referer: `${targetUrl.protocol}//${targetUrl.host}${targetUrl.pathname}`,
+          'User-Agent': ua,
+        },
       },
-    });
+      { timeoutMs: 15000 },
+    );
     if (!response.ok) {
       return jsonError('Failed to fetch key', response.status || 502);
     }

--- a/src/app/api/proxy/logo/route.ts
+++ b/src/app/api/proxy/logo/route.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from 'next/server';
 
 import { getConfig } from '@/lib/config';
+import { fetchWithValidatedRedirects } from '@/lib/proxy-security';
 
 export const runtime = 'nodejs';
 
@@ -21,14 +22,17 @@ export async function GET(request: Request) {
 
   try {
     const decodedUrl = decodeURIComponent(imageUrl);
-    const imageResponse = await fetch(decodedUrl, {
-      cache: 'no-cache',
-      redirect: 'follow',
-      credentials: 'same-origin',
-      headers: {
-        'User-Agent': ua,
+    const imageResponse = await fetchWithValidatedRedirects(
+      decodedUrl,
+      {
+        cache: 'no-cache',
+        credentials: 'same-origin',
+        headers: {
+          'User-Agent': ua,
+        },
       },
-    });
+      { timeoutMs: 10000 },
+    );
 
     if (!imageResponse.ok) {
       return NextResponse.json(

--- a/src/app/api/proxy/m3u8/route.ts
+++ b/src/app/api/proxy/m3u8/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 
 import { getConfig } from '@/lib/config';
 import { getBaseUrl, resolveUrl } from '@/lib/live';
+import { fetchWithValidatedRedirects } from '@/lib/proxy-security';
 import { getEffectiveRequestOrigin } from '@/lib/request-protocol';
 
 export const runtime = 'nodejs';
@@ -108,13 +109,16 @@ export async function GET(request: Request) {
   try {
     const decodedUrl = decodeUpstreamUrl(url);
 
-    response = await fetch(decodedUrl, {
-      cache: 'no-cache',
-      redirect: 'follow',
-      headers: {
-        'User-Agent': ua,
+    response = await fetchWithValidatedRedirects(
+      decodedUrl,
+      {
+        cache: 'no-cache',
+        headers: {
+          'User-Agent': ua,
+        },
       },
-    });
+      { timeoutMs: 15000 },
+    );
 
     if (!response.ok) {
       return jsonError('Failed to fetch m3u8', response.status || 502);

--- a/src/app/api/proxy/segment/route.ts
+++ b/src/app/api/proxy/segment/route.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from 'next/server';
 
 import { getConfig } from '@/lib/config';
+import { fetchWithValidatedRedirects } from '@/lib/proxy-security';
 
 export const runtime = 'nodejs';
 
@@ -107,11 +108,14 @@ export async function GET(request: Request) {
       requestHeaders.set('Range', range);
     }
 
-    const response = await fetch(decodedUrl, {
-      cache: 'no-cache',
-      redirect: 'follow',
-      headers: requestHeaders,
-    });
+    const response = await fetchWithValidatedRedirects(
+      decodedUrl,
+      {
+        cache: 'no-cache',
+        headers: requestHeaders,
+      },
+      { timeoutMs: 30000 },
+    );
 
     if (!response.ok && response.status !== 206) {
       return jsonError('Failed to fetch segment', response.status || 502);

--- a/src/app/api/proxy/stream/route.ts
+++ b/src/app/api/proxy/stream/route.ts
@@ -3,6 +3,7 @@
 import { NextResponse } from 'next/server';
 
 import { getConfig } from '@/lib/config';
+import { fetchWithValidatedRedirects } from '@/lib/proxy-security';
 
 export const runtime = 'nodejs';
 
@@ -71,11 +72,14 @@ export async function GET(request: Request) {
       requestHeaders.set('Range', range);
     }
 
-    const response = await fetch(decodedUrl, {
-      cache: 'no-cache',
-      redirect: 'follow',
-      headers: requestHeaders,
-    });
+    const response = await fetchWithValidatedRedirects(
+      decodedUrl,
+      {
+        cache: 'no-cache',
+        headers: requestHeaders,
+      },
+      { timeoutMs: 30000 },
+    );
 
     if (!response.ok && response.status !== 206) {
       return NextResponse.json(

--- a/src/lib/proxy-security.ts
+++ b/src/lib/proxy-security.ts
@@ -1,5 +1,22 @@
-import { lookup } from 'dns/promises';
-import { isIP } from 'net';
+/*
+ * Proxy target validation helpers.
+ *
+ * Threat model: validateProxyTargetUrl blocks localhost, private/link-local
+ * ranges, and cloud metadata hosts, and fetchWithValidatedRedirects
+ * re-validates every redirect hop before following it. This significantly
+ * reduces SSRF exposure, but it validates DNS answers at check time without
+ * pinning the resolved IP to the actual socket connection. A hostile
+ * authoritative DNS server that flips answers between validation and connect
+ * (DNS rebinding) is therefore mitigated on a best-effort basis, not fully
+ * eliminated. Routes built on these helpers should not be treated as a hard
+ * security boundary for internal networks; keep sensitive internal services
+ * off the deployment's network or behind their own authentication.
+ */
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+const PRIVATE_HOST_ALLOW_ENV = 'PROXY_ALLOW_PRIVATE_HOSTS';
+const PRIVATE_HOST_ALLOWLIST_ENV = 'PROXY_PRIVATE_HOST_ALLOWLIST';
 
 export function normalizeHeaderUrl(
   value: string | null | undefined,
@@ -30,6 +47,10 @@ function isBlockedHostname(hostname: string): boolean {
     hostname.endsWith('.localhost') ||
     hostname === 'metadata.google.internal'
   );
+}
+
+function isAlwaysBlockedHostname(hostname: string): boolean {
+  return !hostname || hostname === 'metadata.google.internal';
 }
 
 function isBlockedIPv4(address: string): boolean {
@@ -80,6 +101,136 @@ function isBlockedAddress(address: string): boolean {
   return true;
 }
 
+function ipv4ToNumber(address: string): number | null {
+  const parts = address.split('.').map((part) => Number(part));
+  if (
+    parts.length !== 4 ||
+    parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)
+  ) {
+    return null;
+  }
+
+  return (
+    ((parts[0] << 24) >>> 0) +
+    ((parts[1] << 16) >>> 0) +
+    ((parts[2] << 8) >>> 0) +
+    (parts[3] >>> 0)
+  );
+}
+
+function isTruthy(value: string | undefined): boolean {
+  return ['1', 'true', 'yes', 'on'].includes((value || '').toLowerCase());
+}
+
+interface PrivateHostAllowlist {
+  enabled: boolean;
+  exactIps: Set<string>;
+  hostnames: Set<string>;
+  ipv4Cidrs: Array<{ base: number; mask: number }>;
+}
+
+function parseAllowlistToken(
+  rawToken: string,
+  allowlist: PrivateHostAllowlist,
+) {
+  const trimmed = rawToken.trim();
+  if (!trimmed) return;
+
+  let token = trimmed;
+  try {
+    if (/^https?:\/\//i.test(token)) {
+      token = new URL(token).hostname;
+    }
+  } catch {
+    return;
+  }
+
+  const cidrMatch = token.match(/^(\d+\.\d+\.\d+\.\d+)\/(\d{1,2})$/);
+  if (cidrMatch) {
+    const base = ipv4ToNumber(cidrMatch[1]);
+    const prefix = Number(cidrMatch[2]);
+    if (
+      base !== null &&
+      Number.isInteger(prefix) &&
+      prefix >= 0 &&
+      prefix <= 32
+    ) {
+      const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+      allowlist.ipv4Cidrs.push({ base: base & mask, mask });
+    }
+    return;
+  }
+
+  const normalized = normalizeHostname(token);
+  const version = isIP(normalized);
+  if (version) {
+    allowlist.exactIps.add(normalized);
+    return;
+  }
+
+  if (normalized) {
+    allowlist.hostnames.add(normalized);
+  }
+}
+
+async function getPrivateHostAllowlist(): Promise<PrivateHostAllowlist> {
+  const allowlist: PrivateHostAllowlist = {
+    enabled: isTruthy(process.env[PRIVATE_HOST_ALLOW_ENV]),
+    exactIps: new Set(),
+    hostnames: new Set(),
+    ipv4Cidrs: [],
+  };
+
+  if (!allowlist.enabled) return allowlist;
+
+  const raw = process.env[PRIVATE_HOST_ALLOWLIST_ENV] || '';
+  for (const token of raw.split(/[\s,]+/)) {
+    parseAllowlistToken(token, allowlist);
+  }
+
+  await Promise.all(
+    Array.from(allowlist.hostnames).map(async (hostname) => {
+      try {
+        const records = await lookup(hostname, { all: true, verbatim: true });
+        for (const record of records) {
+          allowlist.exactIps.add(normalizeHostname(record.address));
+        }
+      } catch {
+        // Ignore allowlist hostnames that cannot be resolved right now.
+      }
+    }),
+  );
+
+  return allowlist;
+}
+
+function isAddressAllowlisted(
+  address: string,
+  allowlist: PrivateHostAllowlist,
+): boolean {
+  const normalized = normalizeHostname(address);
+  if (allowlist.exactIps.has(normalized)) return true;
+
+  const version = isIP(normalized);
+  if (version === 4) {
+    const value = ipv4ToNumber(normalized);
+    return (
+      value !== null &&
+      allowlist.ipv4Cidrs.some(({ base, mask }) => (value & mask) === base)
+    );
+  }
+
+  return false;
+}
+
+function isBlockedAddressAllowed(
+  address: string,
+  allowlist: PrivateHostAllowlist,
+): boolean {
+  if (!allowlist.enabled) return false;
+  return isAddressAllowlisted(address, allowlist);
+}
+
 export async function validateProxyTargetUrl(rawUrl: string): Promise<string> {
   let parsed: URL;
   try {
@@ -97,20 +248,39 @@ export async function validateProxyTargetUrl(rawUrl: string): Promise<string> {
   }
 
   const hostname = normalizeHostname(parsed.hostname);
-  if (isBlockedHostname(hostname)) {
+  if (isAlwaysBlockedHostname(hostname)) {
+    throw new Error('Blocked host');
+  }
+
+  const privateHostAllowlist = await getPrivateHostAllowlist();
+  if (
+    isBlockedHostname(hostname) &&
+    !privateHostAllowlist.hostnames.has(hostname)
+  ) {
     throw new Error('Blocked host');
   }
 
   const literalVersion = isIP(hostname);
   if (literalVersion) {
-    if (isBlockedAddress(hostname)) throw new Error('Blocked IP address');
+    if (
+      isBlockedAddress(hostname) &&
+      !isBlockedAddressAllowed(hostname, privateHostAllowlist)
+    ) {
+      throw new Error('Blocked IP address');
+    }
     return parsed.toString();
   }
 
   const records = await lookup(hostname, { all: true, verbatim: true });
   if (!records.length) throw new Error('Host did not resolve');
 
-  if (records.some((record) => isBlockedAddress(record.address))) {
+  if (
+    records.some(
+      (record) =>
+        isBlockedAddress(record.address) &&
+        !isBlockedAddressAllowed(record.address, privateHostAllowlist),
+    )
+  ) {
     throw new Error('Host resolves to a blocked IP address');
   }
 


### PR DESCRIPTION
## 背景

重做系列的一部分（基于当前最新 `main`，按你的建议拆小）。只包含 SSRF/开放代理防护，不含 auth / cookie / 密码 / 播放 改动。

## 改动

- 新增 `src/lib/proxy-security.ts`：`validateProxyTargetUrl` 拦截 localhost、私网 / 链路本地 / CGNAT 段、云 metadata host 和带凭证的 URL，解析 DNS 并拒绝解析到被封网段的目标；`fetchWithValidatedRedirects` 对每一跳重定向重新校验。
- 私网放行改为显式 opt-in：`PROXY_ALLOW_PRIVATE_HOSTS=true` + `PROXY_PRIVATE_HOST_ALLOWLIST`（支持精确 IP、主机名、IPv4 CIDR），用于自托管 NAS / Jellyfin 等内网媒体。
- 应用到 `/api/proxy/{cms,key,logo,m3u8,segment,stream}`、`/api/download/{proxy,ffmpeg,ffmpeg/file}`、`/api/live/precheck`、`/api/douban/health`。
- 新增代理目标校验回归测试。

## 威胁模型（准确表述）

显著降低 SSRF 风险，但解析到的 IP 未绑定到实际 socket 连接，DNS rebinding / TOCTOU 类风险仅为尽力缓解、并未完全消除，不应把这些接口当作内网的硬性安全边界。

## 验证

- `jest --runInBand` 通过（20 套件 / 106 测试，含新增代理校验测试）
- `pnpm typecheck` 通过
- `docker build` 本分支镜像成功（在干净 checkout 下构建）

不改动登录 / 鉴权流程。