### PR TITLE
fix(docs): 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,11 +801,11 @@ NEXT_PUBLIC_STORAGE_TYPE=redis  # 或 upstash、kvrocks
 ## 📈 Star History
 
 <div align="center">
-  <a href="https://star-history.com/#Decohererk/DecoTV&Date">
+  <a href="https://star-history.dera.page/#Decohererk/DecoTV&type=Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Decohererk/DecoTV&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Decohererk/DecoTV&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Decohererk/DecoTV&type=Date" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Decohererk/DecoTV&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Decohererk/DecoTV&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Decohererk/DecoTV&type=Date" />
     </picture>
   </a>
 </div>


### PR DESCRIPTION
README 中的 Star History 图表目前无法正常显示，影响了仓库的展示效果。本次更新将图表链接切换到可正常工作的新地址，保证 Star 历史图能够稳定加载，方便访客快速了解项目的发展趋势。